### PR TITLE
Emulate Flask's import_path/root_path model to simplify resource loading

### DIFF
--- a/microcosm/metadata.py
+++ b/microcosm/metadata.py
@@ -1,4 +1,6 @@
 """Service metadata"""
+from os.path import abspath, dirname, join
+from sys import modules
 
 
 class Metadata(object):
@@ -9,12 +11,39 @@ class Metadata(object):
 
     """
 
-    def __init__(self, name, debug=False, testing=False):
+    def __init__(self, name, debug=False, testing=False, import_name=None, root_path=None):
         """
         :param name: the name of the microservice
         :param debug: is development debugging enabled?
         :param testing: is unit testing enabled?
+        :param import_name: the import name to use for resource loading
+        :param root_path: the root path for resource loading
+
         """
         self.name = name
         self.debug = debug
         self.testing = testing
+        self.root_path = root_path or self.get_root_path(import_name or name)
+
+    def get_root_path(self, name):
+        """
+        Attempt to compute a root path for a (hopefully importable) name.
+
+        Based in part on Flask's `root_path` calculation. See:
+
+            https://github.com/mitsuhiko/flask/blob/master/flask/helpers.py#L777
+
+        """
+        module = modules.get(name)
+        if module is not None and hasattr(module, '__file__'):
+            return dirname(abspath(module.__file__))
+
+        # Flask keeps looking at this point. We instead set the root path to None,
+        # assume that the user doesn't need resource loading, and raise an error
+        # when resolving the resource path.
+        return None
+
+    def get_path(self, path):
+        if self.root_path is None:
+            raise RuntimeError("Root path was not defined. Either use a resolvable name or set root path explicitly.")
+        return join(self.root_path, path)

--- a/microcosm/object_graph.py
+++ b/microcosm/object_graph.py
@@ -121,7 +121,13 @@ class ObjectGraph(object):
         return component
 
 
-def create_object_graph(name, debug=False, testing=False, loader=load_from_python_file, registry=_registry):
+def create_object_graph(name,
+                        debug=False,
+                        testing=False,
+                        import_name=None,
+                        root_path=None,
+                        loader=load_from_python_file,
+                        registry=_registry):
     """
     Create a new object graph.
 
@@ -135,6 +141,8 @@ def create_object_graph(name, debug=False, testing=False, loader=load_from_pytho
         name=name,
         debug=debug,
         testing=testing,
+        import_name=import_name,
+        root_path=root_path,
     )
 
     config = Configuration({


### PR DESCRIPTION
In a nutshell: we want to use the name of the application as a path to find resources.

We can't just assume the name is a module name, so allow the user to pick an import
name or even set an absolute root path. But don't go to quite the extremes Flask does;
if the user doesn't want to load resources relative to the graph, don't make them.