### PR TITLE
Updated exec statement usage to be python-3 compatible

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,6 +2,10 @@ general:
   artifacts:
      - "dist"
      - "cover"
+dependencies:
+  override:
+    - pip install tox tox-pyenv
+    - pyenv local 2.7.9 3.5.0  # Should correspond to pre-installed Python versions on CircleCI
 test:
   override:
      - tox

--- a/microcosm/loaders.py
+++ b/microcosm/loaders.py
@@ -60,15 +60,17 @@ def load_from_python_file(metadata):
     named after the service of the form FOO_SETTINGS.
 
     """
-    def load_python_module(data):
-        module = new_module("magic")
-        exec(data, module.__dict__, module.__dict__)
-        return {
-            key: value
-            for key, value in module.__dict__.items()
-            if not key.startswith("_")
-        }
-    return _load_from_file(metadata, load_python_module)
+    return _load_from_file(metadata, _load_python_module)
+
+
+def _load_python_module(data):
+    module = new_module("magic")
+    exec(data, module.__dict__, module.__dict__)
+    return {
+        key: value
+        for key, value in module.__dict__.items()
+        if not key.startswith("_")
+    }
 
 
 def _load_from_environ(metadata, value_func=None):

--- a/microcosm/loaders.py
+++ b/microcosm/loaders.py
@@ -62,7 +62,7 @@ def load_from_python_file(metadata):
     """
     def load_python_module(data):
         module = new_module("magic")
-        exec data in module.__dict__, module.__dict__
+        exec(data, module.__dict__, module.__dict__)
         return {
             key: value
             for key, value in module.__dict__.items()

--- a/microcosm/tests/test_loaders.py
+++ b/microcosm/tests/test_loaders.py
@@ -44,7 +44,7 @@ def configfile(data):
     Temporarily create a temporary file.
 
     """
-    configfile_ = NamedTemporaryFile()
+    configfile_ = NamedTemporaryFile(mode='w+')
     configfile_.write(data)
     configfile_.flush()
     yield configfile_

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, lint
+envlist = py27, py35, lint
 
 [testenv]
 commands =


### PR DESCRIPTION
Using the 2to3 tool we found the correct syntax usage for Python3 compatbile invocation of the exec statement.
I also checked this syntax is still Python-2 (backward) compatbile: see https://docs.python.org/2/reference/simple_stmts.html#the-exec-statement :
```
The first expression may also be a tuple of length 2 or 3. In this case, the optional parts must be omitted. The form exec(expr, globals) is equivalent to exec expr in globals, while the form exec(expr, globals, locals) is equivalent to exec expr in globals, locals. The tuple form of exec provides compatibility with Python 3, where exec is a function rather than a statement.
```

- Switch to use exec() form of invocation instead of exec statement
- Refactor the 'load_python_module ' sub-function to top -level function to avoid nasty python 2.7 error
- add [tox-pyenv](https://github.com/samstav/tox-pyenv) plugin support and testing of py3.5 by default
- fix a minor Python3 compatibility issue to do with default binary mode for writing temp file in the loaders unit-tests