### PR TITLE
Allow environment variables configurations to use double underscore for splitting

### DIFF
--- a/microcosm/loaders.py
+++ b/microcosm/loaders.py
@@ -78,7 +78,7 @@ def _load_from_environ(metadata, value_func=None):
     Load configuration from environment variables.
 
     Any environment variable prefixed with the metadata's name will be
-    used to recursively set dictionary keys, splitting on '_'.
+    used to recursively set dictionary keys, splitting on '_' or '__'.
 
     :param value_func: a mutator for the envvar's value (if any)
 
@@ -117,7 +117,8 @@ def _load_from_environ(metadata, value_func=None):
 
     config = Configuration()
     for key, value in environ.items():
-        key_parts = key.split("_")
+        separator = "__" if "__" in key else "_"
+        key_parts = key.split(separator)
         process_env_var(key_parts, value, config)
     return config
 

--- a/microcosm/tests/test_loaders.py
+++ b/microcosm/tests/test_loaders.py
@@ -127,6 +127,23 @@ def test_load_from_environ():
     assert_that(config, is_(equal_to({"bar": "baz", "foo": {"this": "that"}})))
 
 
+def test_load_from_environ_double_underscore():
+    """
+    Return configuration from environment.
+
+    """
+    metadata = Metadata("foo")
+    with envvar("FOO_BAR", "baz"):
+        with envvar("FOO__BAZ", "bar"):
+            with envvar("FOO__BAR_BAZ__THIS", "that"):
+                config = load_from_environ(metadata)
+    assert_that(config, is_(equal_to({
+        "bar": "baz",
+        "baz": "bar",
+        "bar_baz": {"this": "that"}}
+    )))
+
+
 def test_load_multiple_values_for_on_componentfrom_environ():
     """
     Return configuration from environment.


### PR DESCRIPTION
This allows us to distinguish between underscores used in nested dictionary keys and underscores used to separate levels of nesting. For backwards compatibility, if a double underscore is used in a variable name, single underscores are ignored for the purposes of splitting.

Examples:

    PREFIX_FOO_BAR_BAZ    => {"foo": {"bar": "baz"}}
    PREFIX__FOO__BAR__BAZ => {"foo": {"baz": "baz"}}
    PREFIX__FOO_BAR__BAZ  => {"foo_bar": "baz"}
    PREFIX__FOO__BAR_BAZ  => {"foo: "bar_baz"}