### PR TITLE
Add deferred hook processing objects once they have been resolved.

### DIFF
--- a/microcosm/hooks.py
+++ b/microcosm/hooks.py
@@ -1,0 +1,87 @@
+"""
+Object graph hooks.
+
+Provides support for user-defined callbacks during object graph resolution, allowing
+user code to be bound to the same scope as the object graph (instead of, for example,
+global state or some other singleton).
+
+Example:
+
+    @binding("foo")
+    class Foo(object):
+        def __init__(self, graph):
+            self.state = None
+
+
+    def my_hook(foo, state):
+        foo.state = state
+
+
+    on_resolve(Foo, my_hook, "state")
+
+
+In this case, `func` will be invoked at the time that `Foo` is resolved from the graph; this
+will invoke the `my_hook` function and set internal state on the instantiated component.
+
+This pattern is commonly used in conjuction with a decorator to *register* some other state at
+graph load time:
+
+    def register(state):
+        on_resolve(Foo, my_hook, state)
+        return state
+
+
+    @register
+    class Bar(object):
+        passs
+
+
+"""
+
+
+ON_RESOLVE = "_microcosm_on_resolve_"
+
+
+def _invoke_hook(hook_name, target):
+    """
+    Generic hook invocation.
+
+    """
+    try:
+        for value in getattr(target, hook_name):
+            func, args, kwargs = value
+            func(target, *args, **kwargs)
+    except AttributeError:
+        # no hook defined
+        pass
+    except ValueError:
+        # hook not properly defined (might be a MagicMock?)
+        pass
+
+
+def _register_hook(hook_name, target, func, *args, **kwargs):
+    """
+    Generic hook registration.
+
+    """
+    call = (func, args, kwargs)
+    try:
+        getattr(target, hook_name).append(call)
+    except AttributeError:
+        setattr(target, hook_name, [call])
+
+
+def invoke_resolve_hook(target):
+    """
+    Invoke resolution hook.
+
+    """
+    return _invoke_hook(ON_RESOLVE, target)
+
+
+def on_resolve(target, func, *args, **kwargs):
+    """
+    Register a resolution hook.
+
+    """
+    return _register_hook(ON_RESOLVE, target, func, *args, **kwargs)

--- a/microcosm/tests/test_hooks.py
+++ b/microcosm/tests/test_hooks.py
@@ -1,0 +1,79 @@
+"""
+Test hook invocation.
+
+"""
+from hamcrest import (
+    assert_that,
+    contains,
+)
+from microcosm.api import binding, create_object_graph
+from microcosm.hooks import on_resolve
+
+
+def foo_hook(foo, value):
+    foo.callbacks.append(value)
+
+
+@binding("foo")
+class Foo(object):
+
+    def __init__(self, graph):
+        self.callbacks = []
+
+
+@binding("bar")
+def new_foo(graph):
+    return Foo(graph)
+
+
+on_resolve(Foo, foo_hook, "baz")
+
+
+class TestHooks(object):
+    """
+    Test hook invocations.
+
+    """
+    def test_on_resolve_foo_once(self):
+        """
+        Resolving Foo calls the hook.
+
+        """
+        graph = create_object_graph("test")
+        graph.use("foo")
+        graph.lock()
+
+        assert_that(graph.foo.callbacks, contains("baz"))
+
+    def test_on_resolve_foo_again(self):
+        """
+        Resolving Foo again results in only one hook call.
+
+        """
+        graph = create_object_graph("test")
+        graph.use("foo")
+        graph.lock()
+
+        assert_that(graph.foo.callbacks, contains("baz"))
+
+    def test_on_resolve_bar_once(self):
+        """
+        Resolving Foo through a separate factory calls the hook.
+
+        """
+        graph = create_object_graph("test")
+        graph.use("bar")
+        graph.lock()
+
+        assert_that(graph.bar.callbacks, contains("baz"))
+
+    def test_on_resolve_bar_again(self):
+        """
+        Resolving Foo through a separate factory again results in only one hook call.
+
+        """
+        graph = create_object_graph("test")
+        graph.use("bar")
+        graph.lock()
+
+        assert_that(graph.bar.callbacks, contains("baz"))


### PR DESCRIPTION
This is useful for avoiding singleton stores outside of the graph.

We attach a deferred call to an object attribute and call it on resolution. Since we may have multiple members of a singleton, we need a list of hooks.