### PR TITLE
Add profile look for graph load times

### DIFF
--- a/microcosm/profile.py
+++ b/microcosm/profile.py
@@ -1,0 +1,44 @@
+"""
+Factory loading profiling
+
+"""
+from time import time
+
+
+class NoopProfiler(object):
+
+    def __call__(self, key):
+        return self
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, *args, **kargs):
+        pass
+
+
+class TimingProfiler(object):
+
+    def __init__(self):
+        self.times = dict()
+        self.current = []
+
+    def __call__(self, key):
+        self.current.append(key)
+        return self
+
+    def __enter__(self):
+        self.times[self.current[-1]] = time()
+
+    def __exit__(self, *args, **kargs):
+        self.times[self.current[-1]] = time() - self.times[self.current[-1]]
+        self.current.pop()
+
+    def __str__(self):
+        return "\n".join(
+            "{:10.8f} - {}".format(value, key)
+            for key, value in sorted(
+                    self.times.items(),
+                    key=lambda item: -item[1],
+            )[0:20]
+        )

--- a/microcosm/registry.py
+++ b/microcosm/registry.py
@@ -1,4 +1,7 @@
-"""Registry of component factories"""
+"""
+Registry of component factories.
+
+"""
 from itertools import chain
 from pkg_resources import iter_entry_points
 


### PR DESCRIPTION
Some bindings are particularly slow. When optimizing frequent graph
creation (especially during unit testing), it's nice to capture the
graph load behavior.