### PR TITLE
Improvements for graph reusability

### DIFF
--- a/microcosm/caching.py
+++ b/microcosm/caching.py
@@ -8,6 +8,7 @@ Alternate cache implementations can be used to speed up performance
 
 """
 from abc import ABCMeta, abstractmethod
+from collections import defaultdict
 from six import add_metaclass
 
 
@@ -17,7 +18,6 @@ class Cache(object):
     A cache uses the basic dictionary interface and defines a name.
 
     """
-
     @classmethod
     def name(self):
         raise NotImplementedError
@@ -61,20 +61,23 @@ class ProcessCache(Cache):
     time (at the expense of a "clean slate" testing context).
 
     """
-    CACHE = dict()
+    CACHES = defaultdict(dict)
 
     @classmethod
     def name(self):
         return "process"
 
+    def __init__(self, scope="default"):
+        self.scope = scope
+
     def __getitem__(self, name):
-        return ProcessCache.CACHE[name]
+        return ProcessCache.CACHES[self.scope][name]
 
     def __setitem__(self, name, component):
-        ProcessCache.CACHE[name] = component
+        ProcessCache.CACHES[self.scope][name] = component
 
     def __delitem__(self, name):
-        del ProcessCache.CACHE[name]
+        del ProcessCache.CACHES[self.scope][name]
 
 
 def create_cache(name):

--- a/microcosm/object_graph.py
+++ b/microcosm/object_graph.py
@@ -105,6 +105,11 @@ class ObjectGraph(object):
                 raise LockedGraphError(key)
             return self._resolve_key(key)
 
+    def __setattr__(self, key, value):
+        if not key.startswith("_") and key not in ("metadata", "config"):
+            raise Exception("Cannot setattr on ObjectGraph for key: {}".format(key))
+        super(ObjectGraph, self).__setattr__(key, value)
+
     @contextmanager
     def _reserve(self, key):
         """

--- a/microcosm/opaque.py
+++ b/microcosm/opaque.py
@@ -7,8 +7,6 @@ from collections import MutableMapping
 from copy import deepcopy
 from types import MethodType
 
-from microcosm.api import binding
-
 
 def _make_initializer(opaque):
 
@@ -77,6 +75,5 @@ class Opaque(MutableMapping):
         return self._store
 
 
-@binding("opaque")
 def configure_opaque(graph):
     return Opaque(graph.config.opaque)

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ setup(
     ],
     entry_points={
         "microcosm.factories": [
-            "hello_world = microcosm.example:create_hello_world"
+            "hello_world = microcosm.example:create_hello_world",
+            "opaque = microcosm.opaque:configure_opaque",
         ],
     },
     tests_require=[


### PR DESCRIPTION
This PR fixes up several details relevant to graph reuse:

 -  Don't let `setattr` get used on the graph for arbitrary keys.

    Any set attribute circumvents calls to `__getattr__` which means
    ignoring the graph's own cache and factories. This is particularly
    bad because it allows one code unit to interfere with another when
    reusing the graph.

 -  Allow the process cache to use multiple scopes.

    More caching scopes means more flexibility.

 -  Expose the `opaque` binding properly