### PR TITLE
Bring back skip_to parameter

### DIFF
--- a/microcosm/loaders.py
+++ b/microcosm/loaders.py
@@ -18,6 +18,7 @@ from microcosm.configuration import Configuration
 
 def expand_config(dct,
                   separator='.',
+                  skip_to=0,
                   key_func=lambda key: key.lower(),
                   key_parts_filter=lambda key_parts: True,
                   value_func=lambda value: value):
@@ -26,6 +27,7 @@ def expand_config(dct,
 
     :param dct: a non-recursive dictionary
     :param separator: a separator charactor for splitting dictionary keys
+    :param skip_to: index to start splitting keys on; can be used to skip over a key prefix
     :param key_func: a key mapping function
     :param key_parts_filter: a filter function for excluding keys
     :param value_func: a value mapping func
@@ -40,7 +42,7 @@ def expand_config(dct,
             continue
         key_config = config
         # skip prefix
-        for key_part in key_parts[1:-1]:
+        for key_part in key_parts[skip_to:-1]:
             key_config = key_config.setdefault(key_func(key_part), dict())
         key_config[key_func(key_parts[-1])] = value_func(value)
 
@@ -112,6 +114,7 @@ def _load_from_environ(metadata, value_func=None):
     return expand_config(
         environ,
         separator="__",
+        skip_to=1,
         key_parts_filter=lambda key_parts: len(key_parts) > 1 and key_parts[0] == prefix,
         value_func=lambda value: value_func(value) if value_func else value,
     )

--- a/microcosm/tests/test_loaders.py
+++ b/microcosm/tests/test_loaders.py
@@ -66,6 +66,7 @@ def test_expand_config():
                 "this": "that",
             },
             key_parts_filter=lambda key_parts: key_parts[0] == "prefix",
+            skip_to=1,
             value_func=lambda value: value() if callable(value) else value,
         ),
         is_(equal_to(
@@ -127,9 +128,6 @@ def test_load_from_environ():
     Return configuration from environment.
 
     """
-    from os import environ
-    for key in list(environ.keys()):
-        del environ[key]
     metadata = Metadata("foo-dow")
     with envvar("FOO_DOW__BAR", "baz"):
         with envvar("FOO_DOW__BAZ", "bar"):


### PR DESCRIPTION
The default `skip_to=0` parameter is being used by other microcosm libraries (see https://github.com/globality-corp/microcosm-dynamodb/blob/e3a350ddecd3e20b6a44fa6ad99f874aa9ea1e8a/microcosm_dynamodb/loaders/base.py#L56 for example)