### PR TITLE
Experiment ability for factories to be reused with different ("scoped") configurations

### DIFF
--- a/microcosm/constants.py
+++ b/microcosm/constants.py
@@ -1,0 +1,7 @@
+"""
+Shared constants.
+
+"""
+
+
+RESERVED = object()

--- a/microcosm/decorators.py
+++ b/microcosm/decorators.py
@@ -1,4 +1,7 @@
-"""Factory decorators"""
+"""
+Factory decorators
+
+"""
 from microcosm.registry import _registry
 
 

--- a/microcosm/scoping.py
+++ b/microcosm/scoping.py
@@ -1,0 +1,165 @@
+"""
+Scope bindings to multiple configurations.
+
+This feature is EXPERIMENTAL! Use at your own risk.
+
+"""
+from collections import namedtuple
+from contextlib import contextmanager
+from functools import wraps
+
+from microcosm.configuration import Configuration
+from microcosm.decorators import get_defaults
+from microcosm.registry import _registry
+
+
+# NB: currently does not forward graph components
+ScopedGraph = namedtuple("ScopedGraph", ["config", "metadata"])
+
+
+def scoped_binding(key, default_scope=None, registry=_registry):
+    def decorator(func):
+        registry.bind(key, ScopedFactory(key, func, default_scope))
+        return func
+    return decorator
+
+
+class ScopedProxy(object):
+
+    def __init__(self, graph, factory):
+        self.graph = graph
+        self.factory = factory
+
+    def __call__(self, *args, **kwargs):
+        return self.factory.create(self.graph)(*args, **kwargs)
+
+    def __getattr__(self, attr):
+        return getattr(self.factory.create(self.graph), attr)
+
+
+class ScopedFactory(object):
+    """
+    A factory bound to a scoped config key.
+
+    Allows the same binding key (`foo`) to be used to refer to multiple instances
+    of the factory-generated component using different configurations.
+
+    For example, this configuration:
+
+        {
+           "foo": {
+              "host": "host1",
+           },
+           "bar": {
+              "foo": {
+                 "host": "host2",
+              },
+           },
+        }
+
+    Could be used with the same underlying factory to refer to either "host1" or "host2"
+    depending on the current scope.
+
+    """
+    def __init__(self, key, func, default_scope=None):
+        self.key = key
+        self.func = func
+        self.current_scope = default_scope
+        self.default_scope = default_scope
+
+        # cache instances here instead of in the graph cache
+        self.cache = {}
+
+    @property
+    def no_cache(self):
+        """
+        Disable graph caching.
+
+        """
+        return True
+
+    @contextmanager
+    def scoped_to(self, scope):
+        """
+        Context manager to switch scopes.
+
+        """
+        previous_scope = self.current_scope
+        try:
+            self.current_scope = scope
+            yield
+        finally:
+            self.current_scope = previous_scope
+
+    def scoped(self, func):
+        """
+        Decorator to switch scopes.
+
+        """
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            scope = kwargs.pop("scope", self.default_scope)
+            with self.scoped_to(scope):
+                return func(*args, **kwargs)
+        return wrapper
+
+    def get_scoped_config(self, graph):
+        """
+        Compute a configuration using the current scope.
+
+        """
+        # start with the factory's defaults
+        config = Configuration({
+            self.key: get_defaults(self.func),
+        })
+
+        # merge in the appropriate config
+        if self.current_scope is None:
+            target_config = graph.config
+        else:
+            target_config = graph.config.get(self.current_scope, {})
+
+        config.merge({
+            self.key: target_config.get(self.key, {}),
+        })
+        return config
+
+    def __call__(self, graph):
+        """
+        Override component creation to use scoped config.
+
+        """
+        self.create(graph)
+        return ScopedProxy(graph, self)
+
+    def create(self, graph):
+        if self.current_scope in self.cache:
+            return self.cache[self.current_scope]
+
+        scoped_config = self.get_scoped_config(graph)
+
+        scoped_graph = ScopedGraph(
+            config=scoped_config,
+            metadata=graph.metadata,
+        )
+
+        component = self.func(scoped_graph)
+        self.cache[self.current_scope] = component
+        return component
+
+    @classmethod
+    def infect(cls, graph, key, default_scope=None):
+        """
+        Forcibly convert an entry-point based factory to a ScopedFactory.
+
+        Must be invoked before resolving the entry point.
+
+        :raises AlreadyBoundError: for non entry-points; these should be declared with @scoped_binding
+
+        """
+        func = graph.factory_for(key)
+        if isinstance(func, cls):
+            return func
+        factory = cls(key, func, default_scope)
+        graph._registry.bind(key, factory)
+        return factory

--- a/microcosm/scoping.py
+++ b/microcosm/scoping.py
@@ -62,7 +62,7 @@ class ScopedProxy(object):
         """
         @wraps(func)
         def wrapper(*args, **kwargs):
-            scope = kwargs.pop("scope", self.factory.default_scope)
+            scope = kwargs.get("scope", self.factory.default_scope)
             with self.scoped_to(scope):
                 return func(*args, **kwargs)
         return wrapper

--- a/microcosm/tests/test_configuration.py
+++ b/microcosm/tests/test_configuration.py
@@ -1,4 +1,7 @@
-"""Tests for configuration"""
+"""
+Tests for configuration
+
+"""
 from hamcrest import (
     assert_that,
     calling,

--- a/microcosm/tests/test_scoping.py
+++ b/microcosm/tests/test_scoping.py
@@ -1,0 +1,109 @@
+"""
+Test binding scoping.
+
+"""
+from hamcrest import assert_that, equal_to, instance_of, is_
+
+from microcosm.api import create_object_graph, defaults
+from microcosm.loaders import load_from_dict
+from microcosm.scoping import scoped_binding, ScopedFactory
+
+
+@scoped_binding("adder")
+@defaults(
+    first=1,
+    second=2,
+)
+class Adder(object):
+
+    def __init__(self, graph):
+        self.first = graph.config.adder.first
+        self.second = graph.config.adder.second
+
+    def __call__(self):
+        return self.first + self.second
+
+
+@scoped_binding("counter")
+class Counter(object):
+    count = 0
+
+    def __init__(self, graph):
+        Counter.count += 1
+        self.count = Counter.count
+
+
+def test_binding():
+    """
+    Binding functionality works as usual.
+
+    """
+    graph = create_object_graph("example", testing=True)
+    assert_that(graph.adder(), is_(equal_to(3)))
+
+
+def test_scoped_to():
+    """
+    Factory can be scoped to a specific value.
+
+    """
+    loader = load_from_dict(
+        bar=dict(
+            adder=dict(
+                first=3,
+            ),
+        ),
+    )
+    graph = create_object_graph("example", testing=True, loader=loader)
+
+    factory = graph.factory_for("adder")
+
+    with factory.scoped_to("bar"):
+        assert_that(graph.adder(), is_(equal_to(5)))
+
+    with factory.scoped_to("baz"):
+        assert_that(graph.adder(), is_(equal_to(3)))
+
+
+def test_scoped():
+    loader = load_from_dict(
+        bar=dict(
+            adder=dict(
+                first=3,
+            ),
+        ),
+    )
+    graph = create_object_graph("example", testing=True, loader=loader)
+    factory = graph.factory_for("adder")
+
+    @factory.scoped
+    def helper(expected, **kwargs):
+        assert_that(graph.adder(), is_(equal_to(expected)))
+
+    helper(3)
+    helper(5, scope="bar")
+    helper(3, scope="baz")
+
+
+def test_infect_entry_point():
+    """
+    Entry points can be converted to ScopedFactories after-the-fact.
+
+    """
+    graph = create_object_graph("example", testing=True)
+    ScopedFactory.infect(graph, "hello_world")
+
+    factory = graph._registry.resolve("hello_world")
+    assert_that(factory, is_(instance_of(ScopedFactory)))
+
+
+def test_caching():
+    """
+    Caching works (within the scoped factory)
+
+    """
+    graph = create_object_graph("example", testing=True)
+    assert_that(Counter.count, is_(equal_to(0)))
+    assert_that(graph.counter.count, is_(equal_to(1)))
+    assert_that(graph.counter.count, is_(equal_to(1)))
+    assert_that(Counter.count, is_(equal_to(1)))

--- a/microcosm/tests/test_scoping.py
+++ b/microcosm/tests/test_scoping.py
@@ -56,12 +56,10 @@ def test_scoped_to():
     )
     graph = create_object_graph("example", testing=True, loader=loader)
 
-    factory = graph.factory_for("adder")
-
-    with factory.scoped_to("bar"):
+    with graph.adder.scoped_to("bar"):
         assert_that(graph.adder(), is_(equal_to(5)))
 
-    with factory.scoped_to("baz"):
+    with graph.adder.scoped_to("baz"):
         assert_that(graph.adder(), is_(equal_to(3)))
 
 
@@ -74,9 +72,8 @@ def test_scoped():
         ),
     )
     graph = create_object_graph("example", testing=True, loader=loader)
-    factory = graph.factory_for("adder")
 
-    @factory.scoped
+    @graph.adder.scoped
     def helper(expected, **kwargs):
         assert_that(graph.adder(), is_(equal_to(expected)))
 


### PR DESCRIPTION
This PR:
 -  Defines a proxy that dynamically resolves attribute access and calls.
 -  Defines a factory wrapper that switches configuration loading based on a `current_scope`
 -  Defines a few mechanisms for declaring the `current_scope`

Example 1: An explicit `scoped_binding` declares a factory as scoped

    @scoped_binding("key")
    def myfunc(graph):
        pass

Example 2: A call to `infect` converts an entry point factory to a scoped factory:

    ScopedFactory.infect("key")

Example 3: A context manager can be used to switch scopes

    with factory.scoped_to("bar"):
         # uses a compoment configured for bar
         graph.key.something()

Example 4: A decorator can be used to pull scope from arguments

    @factory.scoped
    def myfunction(*args, **kwargs):
         graph.key.something()

    # uses a compoment configured for bar
    myfunction(scope="bar")