### PR TITLE
Better configuration through annotations and decorators

### DIFF
--- a/microcosm/annotations.py
+++ b/microcosm/annotations.py
@@ -1,0 +1,106 @@
+"""
+Configuration annotations.
+
+"""
+from distutils.util import strtobool
+
+
+def boolean(value):
+    """
+    Annotate a value as boolean.
+
+    """
+    if value == "":
+        return False
+    return strtobool(value)
+
+
+def required(value):
+    """
+    Annotate a value as required.
+
+    """
+    if value is None:
+        raise Exception("Missing required value")
+    return value
+
+
+def must_override(metadata, value):
+    """
+    Annotate a value as required outside of unit testing.
+
+    """
+    if metadata.testing:
+        return value
+
+    return required(value)
+
+
+def evaluate(metadata, annotations, config):
+    """
+    Evaluate a set of annotations against a `Configuration`.
+
+    """
+    keys = set(annotations.keys()) | set(config.keys())
+    for key in keys:
+        annotation = annotations.get(key)
+        target = config.get(key)
+
+        try:
+            value = evaluate_one(metadata, key, annotation, target)
+        except Exception as error:
+            print(f"Unable to load configuration for '{key}': {target}")  # noqa
+            raise
+
+        config[key] = value
+
+    return config
+
+
+def split(dct):
+    """
+    Split inputs into data and annotations.
+
+    """
+    data, annotations = dict(), dict()
+
+    for key, value in dct.items():
+        if isinstance(value, dict):
+            data[key], annotations[key] = split(value)
+        elif callable(value):
+            annotations[key] = value
+        else:
+            data[key] = value
+
+    return data, annotations
+
+
+def evaluate_one(metadata, key, annotation, target):
+    """
+    Evaluate a single annotation against its target.
+
+    """
+    if annotation is None:
+        return target
+
+    if isinstance(annotation, dict):
+        if not isinstance(target, dict):
+            raise Exception("Expected dictionary")
+
+        subkeys = set(annotation.keys()) | set(target.keys())
+        return {
+            subkey: evaluate_one(
+                metadata,
+                subkey,
+                annotation.get(subkey),
+                target.get(subkey),
+            )
+            for subkey in subkeys
+        }
+    elif annotation is None:
+        return target
+    else:
+        try:
+            return annotation(target)
+        except TypeError:
+            return annotation(metadata, target)

--- a/microcosm/decorators.py
+++ b/microcosm/decorators.py
@@ -42,3 +42,24 @@ def get_defaults(func):
 
     """
     return getattr(func, DEFAULTS, {})
+
+
+def iter_keys(dct, prefix=""):
+    for key, value in dct.items():
+        if isinstance(value, dict):
+            yield from iter_keys(value, f"{key}.")
+        else:
+            yield f"{prefix}{key}"
+
+
+def public(loader):
+    """
+    Flag a loader as non-secret.
+
+    """
+    def load(metadata):
+        data = loader(metadata)
+        for key in iter_keys(data):
+            metadata.keys["public"].add(key)
+        return data
+    return load

--- a/microcosm/metadata.py
+++ b/microcosm/metadata.py
@@ -2,6 +2,7 @@
 Service metadata
 
 """
+from collections import defaultdict
 from os.path import abspath, dirname, join
 from sys import modules
 
@@ -28,6 +29,7 @@ class Metadata:
         self.testing = testing
         self.import_name = import_name or self.name
         self.root_path = root_path or self.get_root_path(self.import_name)
+        self.keys = defaultdict(set)
 
     def get_root_path(self, name):
         """

--- a/microcosm/object_graph.py
+++ b/microcosm/object_graph.py
@@ -8,6 +8,7 @@ to the graph lazily (or via `graph.use()`) and are cached for reuse.
 """
 from contextlib import contextmanager
 
+from microcosm.annotations import evaluate, split
 from microcosm.caching import create_cache
 from microcosm.configuration import Configuration
 from microcosm.constants import RESERVED
@@ -167,11 +168,15 @@ def create_object_graph(name,
         root_path=root_path,
     )
 
-    config = Configuration({
+    defaults = {
         key: get_defaults(value)
         for key, value in registry.all.items()
-    })
+    }
+
+    data, annotations = split(defaults)
+    config = Configuration(data)
     config.merge(loader(metadata))
+    evaluate(metadata, annotations, config)
 
     if profiler is None:
         profiler = NoopProfiler()

--- a/microcosm/tests/test_annotations.py
+++ b/microcosm/tests/test_annotations.py
@@ -1,0 +1,100 @@
+"""
+Annotation tests.
+
+"""
+from hamcrest import (
+    assert_that,
+    equal_to,
+    has_entries,
+    is_,
+)
+
+from microcosm.api import create_object_graph, binding, defaults
+from microcosm.annotations import boolean, must_override, required, split
+from microcosm.decorators import get_defaults
+from microcosm.loaders import load_from_dict
+from microcosm.registry import Registry
+
+
+REGISTRY = Registry()
+
+
+@binding("integer", REGISTRY)
+@defaults(
+    value=int,
+)
+def integer(graph):
+    return graph.config.integer.value
+
+
+@binding("boolean", REGISTRY)
+@defaults(
+    value=boolean,
+)
+def boolean(graph):
+    return graph.config.boolean.value
+
+
+@binding("component", REGISTRY)
+@defaults(
+    values=must_override,
+    more=required,
+)
+def component(graph):
+    return graph.config.component
+
+
+def test_split_annotations():
+    defaults = {
+        key: get_defaults(value)
+        for key, value in REGISTRY.all.items()
+    }
+    configuration, annotations = split(defaults)
+    assert_that(
+        configuration,
+        has_entries(
+            integer=dict(),
+        ),
+    )
+
+    assert_that(
+        annotations,
+        has_entries(
+            integer=has_entries(
+                value=int,
+            ),
+        ),
+    )
+
+
+def test_annotated_config():
+    loader = load_from_dict(
+        boolean=dict(
+            value="no",
+        ),
+        integer=dict(
+            value="1",
+        ),
+        component=dict(
+            values=[
+                "one",
+                "two",
+            ],
+            more=[
+                "three",
+                "four",
+            ],
+        ),
+    )
+    graph = create_object_graph("test", loader=loader, registry=REGISTRY)
+    assert_that(graph.boolean, is_(equal_to(False)))
+    assert_that(graph.component, is_(equal_to(dict(
+        values=[
+            "one",
+            "two",
+        ],
+        more=[
+            "three",
+            "four",
+        ],
+    ))))


### PR DESCRIPTION
This PR is a first pass refresh of the microcosm configuration mechanism.
It aims to facilitate the following use cases:

 1. Typed values in configuration (esp. boolean/float/integer)
 2. Values that must be specified, either always or outside of unit tests
 3. Values that should be flagged in some other way on lkoad

This requires two features:

 a. We can now split `@defaults` into callable and non-callable values.
    The callables are subsequently applied to the configuration after loading completes.

 b. We can now decrorate loaders with a flagging mechanism and mark their keys
    as such.

Next steps (required before release) include:
 -  Better error reporting
 -  Better composition (e.g. `must_override(int, default=0)`)