### PR TITLE
Add validation of required config parameters

### DIFF
--- a/microcosm/api.py
+++ b/microcosm/api.py
@@ -1,4 +1,6 @@
+from microcosm.config.validation import required, typed
 from microcosm.decorators import binding, defaults
+from microcosm.loaders import load_each, load_from_dict, load_from_environ
 from microcosm.object_graph import create_object_graph
 
 
@@ -6,4 +8,9 @@ __all__ = [
     binding,
     create_object_graph,
     defaults,
+    load_each,
+    load_from_dict,
+    load_from_environ,
+    required,
+    typed,
 ]

--- a/microcosm/config/api.py
+++ b/microcosm/config/api.py
@@ -3,38 +3,19 @@ Configuration API.
 
 """
 from microcosm.config.model import Configuration
-from microcosm.decorators import DEFAULTS
+from microcosm.config.validation import validate
 
 
-def get_defaults(func):
-    """
-    Retrieve the defaults for a factory function.
-
-    """
-    return getattr(func, DEFAULTS, {})
-
-
-def configure(registry, metadata, loader):
+def configure(defaults, metadata, loader):
     """
     Build a fresh configuration.
 
+    :params defaults: a nested dictionary of keys and their default values
+    :params metadata: the graph metadata
+    :params loader: a configuration loader
+
     """
-    config = Configuration({
-        key: get_defaults(value)
-        for key, value in registry.all.items()
-    })
+    config = Configuration(defaults)
     config.merge(loader(metadata))
-    return config
-
-
-def configure_scoped(graph, key, factory, loader):
-    """
-    Build a sub-configuration for a specific binding.
-
-    :params key: a binding key
-    """
-    config = Configuration({
-        key: get_defaults(factory),
-    })
-    config.merge(loader(graph.metadata))
+    validate(defaults, metadata, config)
     return config

--- a/microcosm/config/model.py
+++ b/microcosm/config/model.py
@@ -1,4 +1,8 @@
-"""Configuration model and loading"""
+"""
+Configuration modeling, loading, and validation.
+
+"""
+from microcosm.errors import ValidationError
 
 
 class Configuration(dict):
@@ -63,3 +67,37 @@ class Configuration(dict):
                 self[key] = value
 
     __setitem__ = __setattr__
+
+
+class Requirement:
+    """
+    A value type for configuration defaults that represents *expected* config.
+
+    """
+    def __init__(self, type=str, required=True, mock_value=None, *args, **kwargs):
+        """
+        :param type: a type callable
+        :param mock_value: a default value to use durint testing (only)
+
+        """
+        self.type = type
+        self.required = required
+        self.mock_value = mock_value
+
+    def validate(self, metadata, path, value):
+        """
+        Validate this requirement.
+
+        """
+        if isinstance(value, Requirement):
+            if metadata.testing and self.mock_value is not None:
+                value = self.mock_value
+            elif not value.required:
+                return None
+            else:
+                raise ValidationError(f"Missing required configuration for: {'.'.join(path)}")
+
+        try:
+            return self.type(value)
+        except ValueError:
+            raise ValidationError(f"Missing required configuration for: {'.'.join(path)}: {value}")

--- a/microcosm/config/types.py
+++ b/microcosm/config/types.py
@@ -1,0 +1,21 @@
+"""
+Configuration types.
+
+"""
+from distutils.util import strtobool
+
+
+def boolean(value):
+    """
+    Configuration-friendly boolean type converter.
+
+    Supports both boolean-valued and string-valued inputs (e.g. from env vars).
+
+    """
+    if isinstance(value, bool):
+        return value
+
+    if value == "":
+        return False
+
+    return strtobool(value)

--- a/microcosm/config/validation.py
+++ b/microcosm/config/validation.py
@@ -1,0 +1,52 @@
+"""
+Validation for configuration.
+
+"""
+from microcosm.config.model import Requirement
+
+
+def required(*args, **kwargs):
+    """
+    Fluent requirement declaration.
+
+    """
+    return Requirement(*args, **kwargs)
+
+
+def typed(*args, **kwargs):
+    """
+    Fluent requirement declaration.
+
+    """
+    return Requirement(*args, required=False, **kwargs)
+
+
+def validate(defaults, metadata, config):
+    """
+    Validate configuration.
+
+    """
+    for path, _, default, parent, value in zip_dicts(defaults, config):
+        if isinstance(default, Requirement):
+            # validate the current value and assign the output
+            parent[path[-1]] = default.validate(metadata, path, value)
+
+
+def zip_dicts(left, right, prefix=()):
+    """
+    Modified zip through two dictionaries.
+
+    Iterate through all keys of left dictionary, returning:
+
+      -  A nested path
+      -  A value and parent for both dictionaries
+
+    """
+    for key, left_value in left.items():
+        path = prefix + (key, )
+        right_value = right.get(key)
+
+        if isinstance(left_value, dict):
+            yield from zip_dicts(left_value, right_value or {}, path)
+        else:
+            yield path, left, left_value, right, right_value

--- a/microcosm/constants.py
+++ b/microcosm/constants.py
@@ -4,4 +4,5 @@ Shared constants.
 """
 
 
+DEFAULTS = "_defaults"
 RESERVED = object()

--- a/microcosm/decorators.py
+++ b/microcosm/decorators.py
@@ -2,10 +2,8 @@
 Factory decorators
 
 """
+from microcosm.constants import DEFAULTS
 from microcosm.registry import _registry
-
-
-DEFAULTS = "_defaults"
 
 
 def binding(key, registry=None):

--- a/microcosm/errors.py
+++ b/microcosm/errors.py
@@ -1,4 +1,7 @@
-"""Error types"""
+"""
+Error types
+
+"""
 
 
 class AlreadyBoundError(Exception):
@@ -28,6 +31,14 @@ class LockedGraphError(Exception):
 class NotBoundError(Exception):
     """
     Raised if not factory is bound to a name.
+
+    """
+    pass
+
+
+class ValidationError(Exception):
+    """
+    Raised if a configuration value fails validation.
 
     """
     pass

--- a/microcosm/example.py
+++ b/microcosm/example.py
@@ -1,4 +1,7 @@
-"""Example component factory"""
+"""
+Example component factory
+
+"""
 
 
 def create_hello_world(graph):

--- a/microcosm/object_graph.py
+++ b/microcosm/object_graph.py
@@ -166,7 +166,8 @@ def create_object_graph(name,
         root_path=root_path,
     )
 
-    config = configure(registry, metadata, loader)
+    defaults = registry.defaults
+    config = configure(defaults, metadata, loader)
 
     if profiler is None:
         profiler = NoopProfiler()

--- a/microcosm/registry.py
+++ b/microcosm/registry.py
@@ -7,7 +7,16 @@ from pkg_resources import iter_entry_points
 
 from lazy import lazy
 
+from microcosm.constants import DEFAULTS
 from microcosm.errors import AlreadyBoundError, NotBoundError
+
+
+def get_defaults(func):
+    """
+    Retrieve the defaults for a factory function.
+
+    """
+    return getattr(func, DEFAULTS, {})
 
 
 class Registry:
@@ -34,10 +43,22 @@ class Registry:
     def all(self):
         """
         Return a synthetic dictionary of all factories.
+
         """
         return {
             key: value
             for key, value in chain(self.entry_points.items(), self.factories.items())
+        }
+
+    @property
+    def defaults(self):
+        """
+        Return a nested dicionary of all registered factory defaults.
+
+        """
+        return {
+            key: get_defaults(value)
+            for key, value in self.all.items()
         }
 
     def bind(self, key, factory):

--- a/microcosm/scoping/factories.py
+++ b/microcosm/scoping/factories.py
@@ -2,7 +2,8 @@
 A factory that enables scoping.
 
 """
-from microcosm.config.api import configure_scoped
+from microcosm.config.api import configure
+from microcosm.registry import get_defaults
 from microcosm.scoping.object_graph import ScopedGraph
 from microcosm.scoping.proxies import ScopedProxy
 
@@ -56,7 +57,10 @@ class ScopedFactory:
                 self.key: target.get(self.key, {}),
             }
 
-        return configure_scoped(graph, self.key, self.func, loader)
+        defaults = {
+            self.key: get_defaults(self.func),
+        }
+        return configure(defaults, graph.metadata, loader)
 
     def __call__(self, graph):
         """

--- a/microcosm/tests/config/test_validation.py
+++ b/microcosm/tests/config/test_validation.py
@@ -1,0 +1,106 @@
+"""
+Test validation.
+
+"""
+from hamcrest import (
+    assert_that,
+    calling,
+    has_entries,
+    raises,
+)
+from microcosm.api import binding, defaults, load_from_dict, required, typed
+from microcosm.config.api import configure
+from microcosm.config.types import boolean
+from microcosm.errors import ValidationError
+from microcosm.metadata import Metadata
+from microcosm.registry import Registry
+
+
+class TestValidation:
+
+    def setup(self):
+        self.metadata = Metadata("test")
+        self.registry = Registry()
+
+    def create_fixture(self, requirement):
+        @binding("foo", registry=self.registry)
+        @defaults(
+            value=requirement,
+        )
+        def configure_foo(graph):
+            return graph.foo.value
+
+    def test_valid(self):
+        self.create_fixture(required(int))
+        loader = load_from_dict(
+            foo=dict(
+                value="1",
+            ),
+        )
+
+        config = configure(self.registry.defaults, self.metadata, loader)
+        assert_that(config, has_entries(
+            foo=has_entries(
+                value=1,
+            ),
+        ))
+
+    def test_invalid_missing(self):
+        self.create_fixture(required(int))
+        loader = load_from_dict()
+
+        assert_that(
+            calling(configure).with_args(self.registry.defaults, self.metadata, loader),
+            raises(ValidationError),
+        )
+
+    def test_invalid_malformed(self):
+        self.create_fixture(required(int))
+        loader = load_from_dict(
+            foo=dict(
+                value="bar",
+            ),
+        )
+
+        assert_that(
+            calling(configure).with_args(self.registry.defaults, self.metadata, loader),
+            raises(ValidationError),
+        )
+
+    def test_mock_value(self):
+        self.create_fixture(required(boolean, mock_value="true"))
+        loader = load_from_dict()
+
+        metadata = Metadata("test", testing=True)
+        config = configure(self.registry.defaults, metadata, loader)
+        assert_that(config, has_entries(
+            foo=has_entries(
+                value=True,
+            ),
+        ))
+
+    def test_typed_converted(self):
+        self.create_fixture(typed(int))
+        loader = load_from_dict(
+            foo=dict(
+                value="1",
+            ),
+        )
+
+        config = configure(self.registry.defaults, self.metadata, loader)
+        assert_that(config, has_entries(
+            foo=has_entries(
+                value=1,
+            ),
+        ))
+
+    def test_typed_optional(self):
+        self.create_fixture(typed(int))
+        loader = load_from_dict()
+
+        config = configure(self.registry.defaults, self.metadata, loader)
+        assert_that(config, has_entries(
+            foo=has_entries(
+                value=None,
+            ),
+        ))

--- a/microcosm/tests/test_api.py
+++ b/microcosm/tests/test_api.py
@@ -1,4 +1,7 @@
-"""Test high-level api"""
+"""
+Test high-level api
+
+"""
 
 
 def test_api_imports():

--- a/microcosm/tests/test_decorators.py
+++ b/microcosm/tests/test_decorators.py
@@ -1,16 +1,15 @@
-"""Tests for factory decorators"""
+"""
+Tests for factory decorators
+
+"""
 from hamcrest import (
     assert_that,
     equal_to,
     is_,
 )
 
-from microcosm.decorators import (
-    binding,
-    defaults,
-)
-from microcosm.config.api import get_defaults
-from microcosm.registry import Registry
+from microcosm.decorators import binding, defaults
+from microcosm.registry import get_defaults, Registry
 
 
 def test_defaults():

--- a/microcosm/tests/test_object_graph.py
+++ b/microcosm/tests/test_object_graph.py
@@ -1,4 +1,7 @@
-"""Object Graph Tests"""
+"""
+Object Graph Tests
+
+"""
 from hamcrest import (
     assert_that,
     calling,

--- a/microcosm/tests/test_opaque.py
+++ b/microcosm/tests/test_opaque.py
@@ -8,8 +8,7 @@ from hamcrest import (
     is_,
 )
 
-from microcosm.api import binding, create_object_graph
-from microcosm.loaders import load_from_dict
+from microcosm.api import binding, create_object_graph, load_from_dict
 from microcosm.opaque import Opaque
 
 

--- a/microcosm/tests/test_registry.py
+++ b/microcosm/tests/test_registry.py
@@ -1,4 +1,7 @@
-"""Registry tests"""
+"""
+Registry tests
+
+"""
 from hamcrest import (
     assert_that,
     calling,

--- a/microcosm/tests/test_scoping.py
+++ b/microcosm/tests/test_scoping.py
@@ -4,8 +4,7 @@ Test binding scoping.
 """
 from hamcrest import assert_that, equal_to, instance_of, is_
 
-from microcosm.api import create_object_graph, defaults
-from microcosm.loaders import load_from_dict
+from microcosm.api import create_object_graph, defaults, load_from_dict
 from microcosm.scoping import scoped_binding, ScopedFactory
 
 


### PR DESCRIPTION
Usage:

 -  Assign a `Requirement` to an `@defaults` value, preferably with the `required`
    syntactic sugar.

 -  Define a type conversion (default: string)
 -  Optionally, set `mock_value` for a testing override