### PR TITLE
Find all items in a registry by type

### DIFF
--- a/microcosm/registry.py
+++ b/microcosm/registry.py
@@ -88,6 +88,17 @@ class Registry:
         except NotBoundError:
             return self._resolve_from_entry_point(key)
 
+    def find_by_type(self, value_type):
+        """
+        Find all items of a given type in the registry.
+
+        """
+        return [
+            value
+            for value in self.factories.values()
+            if type(value) == value_type
+        ]
+
     def _resolve_from_binding(self, key):
         """
         Resolve using bindings.

--- a/microcosm/tests/test_registry.py
+++ b/microcosm/tests/test_registry.py
@@ -67,3 +67,15 @@ def test_resolve_not_found():
         calling(registry.resolve).with_args("foo"),
         raises(NotBoundError),
     )
+
+
+def test_find_by_type():
+    """
+    Finds all items in a registry by type.
+
+    """
+    registry = Registry()
+    registry.bind("foo", create_foo)
+    registry.bind("bar", "bar")
+    type_items = registry.find_by_type(type(create_foo))
+    assert_that(type_items, is_(equal_to([create_foo])))


### PR DESCRIPTION
Why?

Allows for easier introspection on the graph.