### PR TITLE
Extend ProcessCache class to have a get function

### DIFF
--- a/microcosm/caching.py
+++ b/microcosm/caching.py
@@ -75,6 +75,9 @@ class ProcessCache(Cache):
     def __contains__(self, name):
         return name in ProcessCache.CACHES[self.scope]
 
+    def get(self, name):
+        return self.__getitem__(name)
+
     def __getitem__(self, name):
         return ProcessCache.CACHES[self.scope][name]
 

--- a/microcosm/tests/test_object_graph.py
+++ b/microcosm/tests/test_object_graph.py
@@ -64,6 +64,7 @@ def test_object_graph_use():
         "parent",
         "hello_world"
     )
+    assert_that(graph.get('parent'), is_(instance_of(Parent)))
     assert_that(parent, is_(instance_of(Parent)))
 
 


### PR DESCRIPTION
Why?

The ObjectGraph's cache expects that its cache has a get function (see https://github.com/globality-corp/microcosm/blob/7bfe7fcece5d231abf83c8b6df5c9672fd8d999a/microcosm/object_graph.py#L81)