### PR TITLE
String and Int list for frontend config parsing

### DIFF
--- a/microcosm/config/types.py
+++ b/microcosm/config/types.py
@@ -3,6 +3,9 @@ Configuration types.
 
 """
 from distutils.util import strtobool
+from re import compile as re_compile
+from json import loads
+from json.decoder import JSONDecodeError
 
 
 def boolean(value):
@@ -19,3 +22,36 @@ def boolean(value):
         return False
 
     return strtobool(value)
+
+
+def string_list(value):
+    if isinstance(value, list):
+        return value
+
+    pattern = re_compile("\['(.*)'\]")
+    match = pattern.match(value)
+
+    if not match:
+        return []
+
+    try:
+        return loads(value.replace("'", "\""))
+    except JSONDecodeError:
+        return []
+
+
+def int_list(value):
+    if isinstance(value, list):
+        return [int(item) for item in value]
+
+    pattern = re_compile("\['(.*)'\]")
+    match = pattern.match(value)
+
+    if not match:
+        return []
+
+    try:
+        parsed_int_list = loads(value.replace("'", "\""))
+        return [int(item) for item in parsed_int_list]
+    except JSONDecodeError:
+        return []

--- a/microcosm/tests/config/test_validation.py
+++ b/microcosm/tests/config/test_validation.py
@@ -10,7 +10,7 @@ from hamcrest import (
 )
 from microcosm.api import binding, defaults, load_from_dict, required, typed
 from microcosm.config.api import configure
-from microcosm.config.types import boolean
+from microcosm.config.types import boolean, string_list, int_list
 from microcosm.errors import ValidationError
 from microcosm.metadata import Metadata
 from microcosm.registry import Registry
@@ -87,6 +87,70 @@ class TestValidation:
         assert_that(config, has_entries(
             foo=has_entries(
                 value=True,
+            ),
+        ))
+
+    def test_int_list_value(self):
+        self.create_fixture(required(int_list))
+        loader = load_from_dict(
+            foo=dict(
+                value="['1', '2']",
+            ),
+        )
+
+        metadata = Metadata("test", testing=True)
+        config = configure(self.registry.defaults, metadata, loader)
+        assert_that(config, has_entries(
+            foo=has_entries(
+                value=[1, 2],
+            ),
+        ))
+
+    def test_int_list_value(self):
+        self.create_fixture(required(int_list))
+        loader = load_from_dict(
+            foo=dict(
+                value="['1', '2']",
+            ),
+        )
+
+        metadata = Metadata("test", testing=True)
+        config = configure(self.registry.defaults, metadata, loader)
+        assert_that(config, has_entries(
+            foo=has_entries(
+                value=[1, 2],
+            ),
+        ))
+
+    def test_list_value_already_list(self):
+        self.create_fixture(required(string_list))
+        loader = load_from_dict(
+            foo=dict(
+                value=["1", "2"],
+            ),
+        )
+
+        metadata = Metadata("test", testing=True)
+        config = configure(self.registry.defaults, metadata, loader)
+        assert_that(config, has_entries(
+            foo=has_entries(
+                value=[1, 2],
+            ),
+        ))
+
+    def test_list_value_already_list(self):
+        self.create_fixture(required(string_list))
+        loader = load_from_dict(
+            foo=dict(
+                value=["item", "another_item"],
+            ),
+        )
+
+        metadata = Metadata("test", testing=True)
+        config = configure(self.registry.defaults, metadata, loader)
+        assert_that(config, has_entries(
+            foo=has_entries(
+                value=["item", "another_item"],
             ),
         ))
 


### PR DESCRIPTION
We are in the process of converting the frontend configuration to be in
environment variables, just like our backend.

The frontend configuration requires lists as part of the files:

```
{
    "someValue": [1,2,3,4]
}

```

In order to accomomdate that, `string_list` and `int_list` were added.