### PR TITLE
Support comma-separated list config values

### DIFF
--- a/microcosm/config/types.py
+++ b/microcosm/config/types.py
@@ -19,3 +19,19 @@ def boolean(value):
         return False
 
     return strtobool(value)
+
+
+def comma_separated_list(value):
+    """
+    Configuration-friendly list type converter.
+
+    Supports both list-valued and string-valued inputs (which are comma-delimited lists of values, e.g. from env vars).
+
+    """
+    if isinstance(value, list):
+        return value
+
+    if value == "":
+        return []
+
+    return value.split(",")

--- a/microcosm/tests/config/test_validation.py
+++ b/microcosm/tests/config/test_validation.py
@@ -102,6 +102,30 @@ class TestValidation:
             ),
         ))
 
+    def test_comma_separated_list_empty(self):
+        self.create_fixture(typed(comma_separated_list, mock_value=""))
+        loader = load_from_dict()
+
+        metadata = Metadata("test", testing=True)
+        config = configure(self.registry.defaults, metadata, loader)
+        assert_that(config, has_entries(
+            foo=has_entries(
+                value=[],
+            ),
+        ))
+
+    def test_comma_separated_list_unconverted(self):
+        self.create_fixture(typed(comma_separated_list, mock_value=["abc", "def", "ghi"]))
+        loader = load_from_dict()
+
+        metadata = Metadata("test", testing=True)
+        config = configure(self.registry.defaults, metadata, loader)
+        assert_that(config, has_entries(
+            foo=has_entries(
+                value=["abc", "def", "ghi"],
+            ),
+        ))
+
     def test_typed_converted(self):
         self.create_fixture(typed(int))
         loader = load_from_dict(

--- a/microcosm/tests/config/test_validation.py
+++ b/microcosm/tests/config/test_validation.py
@@ -10,7 +10,7 @@ from hamcrest import (
 )
 from microcosm.api import binding, defaults, load_from_dict, required, typed
 from microcosm.config.api import configure
-from microcosm.config.types import boolean
+from microcosm.config.types import boolean, comma_separated_list
 from microcosm.errors import ValidationError
 from microcosm.metadata import Metadata
 from microcosm.registry import Registry
@@ -87,6 +87,18 @@ class TestValidation:
         assert_that(config, has_entries(
             foo=has_entries(
                 value=True,
+            ),
+        ))
+
+    def test_comma_separated_list_converted(self):
+        self.create_fixture(typed(comma_separated_list, mock_value="abc,def,ghi"))
+        loader = load_from_dict()
+
+        metadata = Metadata("test", testing=True)
+        config = configure(self.registry.defaults, metadata, loader)
+        assert_that(config, has_entries(
+            foo=has_entries(
+                value=["abc", "def", "ghi"],
             ),
         ))
 


### PR DESCRIPTION
I [recently](https://github.com/globality-corp/picasso/pull/167/files#diff-ea843e883c6a5c1672ba7f5b698544a6R43) had to define a list-valued config value to a new picasso daemon.

I realized we had a [couple](https://github.com/globality-corp/sphinx/blob/aac42c115854f96a7f384b3f9aee58552b45e744/sphinx/routes/rule_context_goal/controller.py#L20) of places we do this in (e.g. pythia/sphinx), but these rely on in-place parsing of the string value into list.

Seemed like a nice use case for our configuration types system to take on the parsing responsibility so consumer code can be agnostic, similar to the existing `boolean` type..