### PR TITLE
Add twine support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,8 +141,10 @@ jobs:
             echo "username:$PYPI_USERNAME" >> ~/.pypirc
             echo "password:$PYPI_PASSWORD" >> ~/.pypirc
             echo >> ~/.pypirc
+            version=$(cat .bumpversion.cfg | awk '/current_version / {print $3}')
             python setup.py register -r pypi
-            python setup.py sdist upload -r pypi
+            python setup.py sdist
+            twine upload dist/microcosm-${version}.tar.gz
 
 workflows:
   version: 2


### PR DESCRIPTION
This is necessary in order for our README to publish correctly.  See [this failure](https://circleci.com/gh/globality-corp/microcosm/431).