### PR TITLE
globality-build 2019.23.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@
 defaults: &defaults
   working_directory: ~/repo
   docker:
-    - image: ${AWS_ECR_DOMAIN}/globality-build:faaff99432ff46b774e40a2f6a44e628e9955070
+    - image: ${AWS_ECR_DOMAIN}/globality-build:2019.23.2
       aws_auth:
         aws_access_key_id: ${AWS_ACCESS_KEY_ID}
         aws_secret_access_key: ${AWS_SECRET_ACCESS_KEY}
@@ -28,7 +28,7 @@ defaults: &defaults
 deploy_defaults: &deploy_defaults
   working_directory: ~/repo
   docker:
-    - image: ${AWS_ECR_DOMAIN}/globality-build:faaff99432ff46b774e40a2f6a44e628e9955070
+    - image: ${AWS_ECR_DOMAIN}/globality-build:2019.23.2
       aws_auth:
         aws_access_key_id: ${AWS_ACCESS_KEY_ID}
         aws_secret_access_key: ${AWS_SECRET_ACCESS_KEY}

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,6 @@
 *
 !microcosm
-microcosm/test*
+microcosm/tests
 !dist/*-none-any.whl
 !entrypoint.sh
 !MANIFEST.in

--- a/.globality/build.json
+++ b/.globality/build.json
@@ -6,5 +6,5 @@
     }
   },
   "type": "python-library",
-  "version": "2019.20.1"
+  "version": "2019.23.2"
 }

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,5 @@
 [flake8]
+exclude = */migrations/*,.eggs/*
 max-line-length = 120
 max-complexity = 15
 
@@ -8,8 +9,8 @@ enforce_white_space = True
 force_grid_wrap = 4
 include_trailing_comma = True
 known_first_party = microcosm
-known_standard_library = pkg_resources,dataclasses
-known_third_party = six,hamcrest,nose_parameterized,microcosm,unidecode,nose
+known_standard_library = dataclasses,pkg_resources
+known_third_party = six,hamcrest,parameterized,microcosm,unidecode,nose
 line_length = 99
 lines_after_imports = 2
 multi_line_output = 3


### PR DESCRIPTION
Removes the temporary workaround using specific tagged version of `globality-build`