### PR TITLE
First pass adding jaeger to microcosm.

### DIFF
--- a/microcosm/opaque.py
+++ b/microcosm/opaque.py
@@ -51,7 +51,7 @@ def _make_initializer(opaque):
 
                 span = self.enter_context(
                     opaque.tracer.start_span(
-                        opaque.get("name", opaque.service_name),
+                        opaque.get("span_name", opaque.service_name),
                         child_of=span_context,
                         tags=span_tags,
                     ),

--- a/microcosm/opaque.py
+++ b/microcosm/opaque.py
@@ -27,6 +27,8 @@ from opentracing.ext import tags
 from opentracing.propagation import Format
 from opentracing_instrumentation.request_context import span_in_context
 
+from microcosm.tracing import SPAN_NAME
+
 
 def _make_initializer(opaque):
 
@@ -56,11 +58,12 @@ def _make_initializer(opaque):
             initialize a span for this opaque context.
             """
             span_context = opaque.tracer.extract(Format.TEXT_MAP, opaque.as_dict())
+            print("span context: ", span_context)
             span_tags = {tags.SPAN_KIND: tags.SPAN_KIND_RPC_SERVER}
 
             return self.enter_context(
                 opaque.tracer.start_span(
-                    opaque.get("span_name", opaque.service_name),
+                    opaque.get(SPAN_NAME, opaque.service_name),
                     child_of=span_context,
                     tags=span_tags,
                 ),
@@ -81,6 +84,7 @@ def _make_initializer(opaque):
             boundaries.
 
             """
+            print("making trace")
             self.enter_context(span_in_context(span))
             span_dict = dict()
             opaque.tracer.inject(span, Format.HTTP_HEADERS, span_dict)

--- a/microcosm/opaque.py
+++ b/microcosm/opaque.py
@@ -58,7 +58,6 @@ def _make_initializer(opaque):
             initialize a span for this opaque context.
             """
             span_context = opaque.tracer.extract(Format.TEXT_MAP, opaque.as_dict())
-            print("span context: ", span_context)
             span_tags = {tags.SPAN_KIND: tags.SPAN_KIND_RPC_SERVER}
 
             return self.enter_context(
@@ -84,7 +83,6 @@ def _make_initializer(opaque):
             boundaries.
 
             """
-            print("making trace")
             self.enter_context(span_in_context(span))
             span_dict = dict()
             opaque.tracer.inject(span, Format.HTTP_HEADERS, span_dict)

--- a/microcosm/tests/test_opaque.py
+++ b/microcosm/tests/test_opaque.py
@@ -116,7 +116,6 @@ class Child:
         self.opaque = graph.opaque
 
     def __call__(self):
-        print("self.opaque : ", self.opaque.as_dict())
         return self.opaque.as_dict()
 
 

--- a/microcosm/tests/test_opaque.py
+++ b/microcosm/tests/test_opaque.py
@@ -137,7 +137,7 @@ def test_collaboration():
     )
     graph.lock()
 
-    assert_that(graph.opaque.as_dict(), not_(has_key(TRACE_ID_HEADER))) 
+    assert_that(graph.opaque.as_dict(), not_(has_key(TRACE_ID_HEADER)))
     # we should be able to initialize the opaque data and observe it from the collaborators
     decorated_func = graph.opaque.initialize(
         example_func, OTHER, OTHER

--- a/microcosm/tests/test_opaque.py
+++ b/microcosm/tests/test_opaque.py
@@ -6,9 +6,9 @@ from hamcrest import (
     assert_that,
     equal_to,
     has_entries,
+    has_key,
     is_,
     not_,
-    has_key,
 )
 
 from microcosm.api import binding, create_object_graph, load_from_dict

--- a/microcosm/tests/test_opaque.py
+++ b/microcosm/tests/test_opaque.py
@@ -2,7 +2,12 @@
 Opaque context tests.
 
 """
-from hamcrest import assert_that, equal_to, is_, has_entries
+from hamcrest import (
+    assert_that,
+    equal_to,
+    has_entries,
+    is_,
+)
 
 from microcosm.api import binding, create_object_graph, load_from_dict
 from microcosm.opaque import Opaque

--- a/microcosm/tests/test_opaque.py
+++ b/microcosm/tests/test_opaque.py
@@ -10,10 +10,10 @@ from hamcrest import (
     is_,
     not_,
 )
+from jaeger_client.constants import TRACE_ID_HEADER
 
 from microcosm.api import binding, create_object_graph, load_from_dict
 from microcosm.opaque import Opaque
-from microcosm.tracing import TRACE_ID
 
 
 THIS = "this"
@@ -137,8 +137,7 @@ def test_collaboration():
     )
     graph.lock()
 
-    assert_that(graph.opaque.as_dict(), not_(has_key(TRACE_ID)))
-
+    assert_that(graph.opaque.as_dict(), not_(has_key(TRACE_ID_HEADER))) 
     # we should be able to initialize the opaque data and observe it from the collaborators
     decorated_func = graph.opaque.initialize(
         example_func, OTHER, OTHER
@@ -147,5 +146,5 @@ def test_collaboration():
     assert_that(graph.opaque.as_dict(), is_(equal_to({THIS: VALUE})))
     # NB: opaque.intialize will also inject some jaeger-related metadata which the tests can ignore.
     assert_that(decorated_func(), has_entries(example_func(OTHER, OTHER)))
-    assert_that(decorated_func(), has_key(TRACE_ID))
+    assert_that(decorated_func(), has_key(TRACE_ID_HEADER))
     assert_that(graph.opaque.as_dict(), is_(equal_to({THIS: VALUE})))

--- a/microcosm/tests/test_opaque.py
+++ b/microcosm/tests/test_opaque.py
@@ -2,7 +2,7 @@
 Opaque context tests.
 
 """
-from hamcrest import assert_that, equal_to, is_
+from hamcrest import assert_that, equal_to, is_, has_entries
 
 from microcosm.api import binding, create_object_graph, load_from_dict
 from microcosm.opaque import Opaque
@@ -133,5 +133,6 @@ def test_collaboration():
     )(graph.parent_collaborator.__call__)
 
     assert_that(graph.opaque.as_dict(), is_(equal_to({THIS: VALUE})))
-    assert_that(decorated_func(), is_(equal_to(example_func(OTHER, OTHER))))
+    # NB: opaque.intialize will also inject some jaeger-related metadata which the tests can ignore.
+    assert_that(decorated_func(), has_entries(example_func(OTHER, OTHER)))
     assert_that(graph.opaque.as_dict(), is_(equal_to({THIS: VALUE})))

--- a/microcosm/tracing.py
+++ b/microcosm/tracing.py
@@ -14,6 +14,10 @@ def configure_tracing(graph):
     available sampling strategies.
 
     """
+    if graph.metadata.testing:
+        from unittest.mock import Mock
+        return Mock()
+
     config = Config(
         config={
             'sampler': {

--- a/microcosm/tracing.py
+++ b/microcosm/tracing.py
@@ -1,0 +1,27 @@
+from jaeger_client import Config
+
+from microcosm.api import binding, defaults, typed
+
+
+@binding("tracer")
+@defaults(
+    sample_type="ratelimiting",
+    sample_param=typed(int, 10),
+)
+def configure_tracing(graph):
+    """
+    See https://www.jaegertracing.io/docs/1.12/sampling/ for more info about
+    available sampling strategies.
+
+    """
+    config = Config(
+        config={
+            'sampler': {
+                'type': graph.config.tracer.sample_type,
+                'param': graph.config.tracer.sample_param,
+            },
+            'logging': True,
+        },
+        service_name=graph.metadata.name,
+    )
+    return config.initialize_tracer()

--- a/microcosm/tracing.py
+++ b/microcosm/tracing.py
@@ -1,9 +1,13 @@
-from jaeger_client import Config
+from jaeger_client.config import (
+    Config,
+    DEFAULT_SAMPLING_PORT,
+    DEFAULT_REPORTING_PORT,
+    DEFAULT_REPORTING_HOST,
+)
 
 from microcosm.api import binding, defaults, typed
 
 
-TRACE_ID = "uber-trace-id"
 SPAN_NAME = "span_name"
 
 
@@ -11,6 +15,9 @@ SPAN_NAME = "span_name"
 @defaults(
     sample_type="ratelimiting",
     sample_param=typed(int, 10),
+    sampling_port=typed(int, DEFAULT_SAMPLING_PORT),
+    reporting_port=typed(int, DEFAULT_REPORTING_PORT),
+    reporting_host=DEFAULT_REPORTING_HOST,
 )
 def configure_tracing(graph):
     """
@@ -20,11 +27,16 @@ def configure_tracing(graph):
     """
     config = Config(
         config={
-            'sampler': {
-                'type': graph.config.tracer.sample_type,
-                'param': graph.config.tracer.sample_param,
+            "sampler": {
+                "type": graph.config.tracer.sample_type,
+                "param": graph.config.tracer.sample_param,
             },
-            'logging': True,
+            "local_agent": {
+                "sampling_port": graph.config.tracer.sampling_port,
+                "reporting_port": graph.config.tracer.reporting_port,
+                "reporting_host": graph.config.tracer.reporting_host,
+            },
+            "logging": True,
         },
         service_name=graph.metadata.name,
     )

--- a/microcosm/tracing.py
+++ b/microcosm/tracing.py
@@ -2,6 +2,7 @@ from jaeger_client import Config
 
 from microcosm.api import binding, defaults, typed
 
+
 TRACE_ID = "uber-trace-id"
 SPAN_NAME = "span_name"
 

--- a/microcosm/tracing.py
+++ b/microcosm/tracing.py
@@ -1,5 +1,3 @@
-from contextlib import nullcontext
-
 from jaeger_client import Config
 
 from microcosm.api import binding, defaults, typed
@@ -16,12 +14,6 @@ def configure_tracing(graph):
     available sampling strategies.
 
     """
-    if graph.metadata.testing:
-        from unittest.mock import Mock
-        mock = Mock()
-        mock.start_span = nullcontext
-        return mock
-
     config = Config(
         config={
             'sampler': {

--- a/microcosm/tracing.py
+++ b/microcosm/tracing.py
@@ -1,3 +1,5 @@
+from contextlib import nullcontext
+
 from jaeger_client import Config
 
 from microcosm.api import binding, defaults, typed
@@ -16,7 +18,9 @@ def configure_tracing(graph):
     """
     if graph.metadata.testing:
         from unittest.mock import Mock
-        return Mock()
+        mock = Mock()
+        mock.start_span = nullcontext
+        return mock
 
     config = Config(
         config={

--- a/microcosm/tracing.py
+++ b/microcosm/tracing.py
@@ -1,8 +1,8 @@
 from jaeger_client.config import (
-    Config,
-    DEFAULT_SAMPLING_PORT,
-    DEFAULT_REPORTING_PORT,
     DEFAULT_REPORTING_HOST,
+    DEFAULT_REPORTING_PORT,
+    DEFAULT_SAMPLING_PORT,
+    Config,
 )
 
 from microcosm.api import binding, defaults, typed

--- a/microcosm/tracing.py
+++ b/microcosm/tracing.py
@@ -2,6 +2,9 @@ from jaeger_client import Config
 
 from microcosm.api import binding, defaults, typed
 
+TRACE_ID = "uber-trace-id"
+SPAN_NAME = "span_name"
+
 
 @binding("tracer")
 @defaults(

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,9 @@ setup(
     install_requires=[
         "contextdecorator>=0.10.0",
         "inflection>=0.3.1",
+        "jaeger-client>=4.0.0",
         "lazy>=1.3",
+        "opentracing-instrumentation>=3.0.1",
     ],
     setup_requires=[
         "nose>=1.3.6",

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         "microcosm.factories": [
             "hello_world = microcosm.example:create_hello_world",
             "opaque = microcosm.opaque:configure_opaque",
+            "tracer = microcosm.tracing:configure_tracing",
         ],
     },
     tests_require=[


### PR DESCRIPTION
Why? We have already done much of the work of making our system
traceable with `opaque`. By integrating this with `jaeger` we can get
very nice instrumentation.

Opening for early review. This + a marquez change gets us 90% of the way there. The added benefit of integrating `jaeger` directly with `opaque` is that this should let us track 90% of the same footpath as `request-id` does with only this change and a `marquez` update.

<img width="1434" alt="Screen Shot 2019-07-08 at 7 24 44 PM" src="https://user-images.githubusercontent.com/5201654/60848799-1336f780-a1b6-11e9-9e87-a75efe0e5b03.png">

The part that I'm really happy about is that this automatically tags `jaeger` spans with the metadata from `opaque`. If this gets too noisy we can add a white list, but looking at the stuff that `microcosm-pubsub` already adds to opaque, we should get the handler name and the request id so this seems very nice.

See also: https://github.com/globality-corp/microcosm-flask/pull/216 support marshalling/unmarshalling the jaeger headers in mc flask
