### PR TITLE
Add default_factory; exclusive requirements

### DIFF
--- a/microcosm/config/model.py
+++ b/microcosm/config/model.py
@@ -110,7 +110,13 @@ class Requirement:
                 "Must either specify `required=True` or provide default value.",
                 category=FutureWarning,
             )
-        elif len(list(filter(None, [default_value, default_factory, required]))) != 1:
+        elif len(
+            list(filter(None, [
+                required,
+                default_value is not None,
+                default_factory is not None,
+            ])),
+        ) != 1:
             # For all situations where user doesn't provide exactly one of
             #
             # [`required=True`, `default_value=...`, `default_factory=...`]

--- a/microcosm/config/model.py
+++ b/microcosm/config/model.py
@@ -100,6 +100,13 @@ class Requirement:
         self.required = required
         self.nullable = nullable or (default_value is None)
 
+        if kwargs:
+            warn(
+                f"Unsupported `Requirement` args {kwargs}.  "
+                "Support for arbitrary arguments to `Requirement` will be dropped",
+                category=FutureWarning,
+            )
+
         if default_factory is None and required == (default_value is not UNSET):
             # Warn when the user doesn't provide exactly one of
             #

--- a/microcosm/config/model.py
+++ b/microcosm/config/model.py
@@ -110,13 +110,16 @@ class Requirement:
                 "Must either specify `required=True` or provide default value.",
                 category=FutureWarning,
             )
-        elif len(
-            list(filter(None, [
-                required,
+        elif any([
+            required and any([
                 default_value is not None,
                 default_factory is not None,
-            ])),
-        ) != 1:
+            ]),
+            all([
+                default_factory is not None,
+                default_value is not None,
+            ]),
+        ]):
             # For all situations where user doesn't provide exactly one of
             #
             # [`required=True`, `default_value=...`, `default_factory=...`]

--- a/microcosm/config/model.py
+++ b/microcosm/config/model.py
@@ -101,31 +101,23 @@ class Requirement:
         #
         # [`required=True`, `default_value=...`]
         #
-        # In the future this will be an error, but for now we just warn in
-        # those situations which could occur as of the time this was introduced
-        warned = False
-        if default_factory is None:
-            if required and (default_value is not None):
-                warned = True
-                warn(
-                    "Cannot specify default value when `required=True`.",
-                    category=FutureWarning,
-                )
-            if not required and default_value is None:
-                warned = True
-                warn(
-                    "Must either specify `required=True` or provide default value.",
-                    category=FutureWarning,
-                )
-
-        # For all situations where user doesn't provide exactly one of
-        #
-        # [`required=True`, `default_value=...`, `default_factory=...`]
-        #
-        # and it's using newly introduced features, we error, so that new
-        # issues can't be introduced going forward.  In the future, we will
-        # just perform this check and remove the warning above
-        if not warned and len(list(filter(None, [default_value, default_factory, required]))) != 1:
+        # When the user is not using `default_factory`, this could be legacy
+        # code, so we just warn. In the future this will be an error, but for
+        # now we just warn in those situations which could occur as of the time
+        # this was introduced
+        if default_factory is None and required == (default_value is not None):
+            warn(
+                "Must either specify `required=True` or provide default value.",
+                category=FutureWarning,
+            )
+        elif len(list(filter(None, [default_value, default_factory, required]))) != 1:
+            # For all situations where user doesn't provide exactly one of
+            #
+            # [`required=True`, `default_value=...`, `default_factory=...`]
+            #
+            # and it's using newly introduced features, we error, so that new
+            # issues can't be introduced going forward.  In the future, we will
+            # just perform this check and remove the warning above
             raise ValueError(
                 "Expected exactly one of "
                 "[default_value, default_factory, required], "

--- a/microcosm/config/model.py
+++ b/microcosm/config/model.py
@@ -100,24 +100,35 @@ class Requirement:
         self.required = required
         self.nullable = nullable
 
-        # Warn when the user doesn't provide exactly one of
-        #
-        # [`required=True`, `default_value=...`]
-        #
-        # When the user is not using `default_factory`, this could be legacy
-        # code, so we just warn. In the future this will be an error, but for
-        # now we just warn in those situations which could occur as of the time
-        # this was introduced
         if default_factory is None and required == (default_value is not UNSET):
+            # Warn when the user doesn't provide exactly one of
+            #
+            # [`required=True`, `default_value=...`]
+            #
+            # When the user is not using `default_factory`, this could be legacy
+            # code, so we just warn. In the future we will remove this clause
+            # and just use the error clause below, but for now we just warn in
+            # those situations which could occur as of the time this was
+            # introduced
             warn(
                 "Must either specify `required=True` or provide default value.",
                 category=FutureWarning,
             )
         elif any([
+            # Must either require a value or provide a default
+            all([
+                not required,
+                default_value is UNSET,
+                default_factory is None,
+            ]),
+
+            # Can't require a value and also specify a default
             required and any([
                 default_value is not UNSET,
                 default_factory is not None,
             ]),
+
+            # Can't specify both a default value and a default factory
             all([
                 default_value is not UNSET,
                 default_factory is not None,

--- a/microcosm/config/model.py
+++ b/microcosm/config/model.py
@@ -98,7 +98,7 @@ class Requirement:
         self.default_factory = default_factory
         self.mock_value = mock_value
         self.required = required
-        self.nullable = nullable
+        self.nullable = nullable or (default_value is None)
 
         if default_factory is None and required == (default_value is not UNSET):
             # Warn when the user doesn't provide exactly one of

--- a/microcosm/config/sentinel.py
+++ b/microcosm/config/sentinel.py
@@ -1,0 +1,6 @@
+class _Unset:
+    def __repr__(self):
+        return '<value not set>'
+
+
+UNSET = _Unset()

--- a/microcosm/tests/config/check_warnings.py
+++ b/microcosm/tests/config/check_warnings.py
@@ -1,0 +1,36 @@
+import warnings
+from contextlib import contextmanager
+
+from hamcrest import (
+    assert_that,
+    contains_string,
+    empty,
+    equal_to,
+    has_length,
+    is_,
+)
+
+
+@contextmanager
+def check_requirements_exactly_one_warning(expect_string):
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+
+        yield
+
+        assert_that(w, has_length(1))
+        warning = w[-1]
+
+        assert_that(str(warning.message), contains_string(expect_string))
+        assert_that(warning.category, is_(equal_to(FutureWarning)))
+
+
+@contextmanager
+def check_no_warnings():
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+
+        yield
+
+        if w:
+            assert_that(w, is_(empty()), w[-1].message)

--- a/microcosm/tests/config/check_warnings.py
+++ b/microcosm/tests/config/check_warnings.py
@@ -12,7 +12,7 @@ from hamcrest import (
 
 
 @contextmanager
-def check_requirements_exactly_one_warning(expect_string):
+def check_requirements_exactly_one_warning():
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
 
@@ -21,7 +21,7 @@ def check_requirements_exactly_one_warning(expect_string):
         assert_that(w, has_length(1))
         warning = w[-1]
 
-        assert_that(str(warning.message), contains_string(expect_string))
+        assert_that(str(warning.message), contains_string("Must either"))
         assert_that(warning.category, is_(equal_to(FutureWarning)))
 
 

--- a/microcosm/tests/config/check_warnings.py
+++ b/microcosm/tests/config/check_warnings.py
@@ -12,7 +12,7 @@ from hamcrest import (
 
 
 @contextmanager
-def check_requirements_exactly_one_warning():
+def check_warning(message):
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
 
@@ -21,8 +21,16 @@ def check_requirements_exactly_one_warning():
         assert_that(w, has_length(1))
         warning = w[-1]
 
-        assert_that(str(warning.message), contains_string("Must either"))
+        assert_that(str(warning.message), contains_string(message))
         assert_that(warning.category, is_(equal_to(FutureWarning)))
+
+
+def check_requirements_exactly_one_warning():
+    return check_warning("Must either")
+
+
+def check_unsupported_arg_warning():
+    return check_warning("Unsupported")
 
 
 @contextmanager

--- a/microcosm/tests/config/test_validation.py
+++ b/microcosm/tests/config/test_validation.py
@@ -117,6 +117,18 @@ class TestValidation:
         ))
 
     @check_no_warnings()
+    def test_null_default_implies_nullable(self):
+        self.create_fixture(typed(int, default_value=None))
+        loader = load_from_dict()
+
+        config = configure(self.registry.defaults, self.metadata, loader)
+        assert_that(config, has_entries(
+            foo=has_entries(
+                value=None,
+            ),
+        ))
+
+    @check_no_warnings()
     def test_valid_default_factory(self):
         self.create_fixture(typed(list, default_factory=list))
         loader = load_from_dict()

--- a/microcosm/tests/config/test_validation.py
+++ b/microcosm/tests/config/test_validation.py
@@ -188,7 +188,7 @@ class TestValidation:
             ),
         ))
 
-    @check_requirements_exactly_one_warning("Must either")
+    @check_requirements_exactly_one_warning()
     def test_missing_default(self):
         self.create_fixture(typed(int))
         loader = load_from_dict()
@@ -200,7 +200,7 @@ class TestValidation:
             ),
         ))
 
-    @check_requirements_exactly_one_warning("Cannot specify")
+    @check_requirements_exactly_one_warning()
     def test_default_and_required(self):
         self.create_fixture(required(int, default_value="1"))
         loader = load_from_dict()

--- a/microcosm/tests/config/test_validation.py
+++ b/microcosm/tests/config/test_validation.py
@@ -83,6 +83,40 @@ class TestValidation:
         ))
 
     @check_no_warnings()
+    def test_nullable(self):
+        self.create_fixture(typed(
+            int,
+            default_value=0,
+            nullable=True,
+            mock_value=None,
+        ))
+        loader = load_from_dict()
+
+        metadata = Metadata("test", testing=True)
+        config = configure(self.registry.defaults, metadata, loader)
+        assert_that(config, has_entries(
+            foo=has_entries(
+                value=None,
+            ),
+        ))
+
+    @check_no_warnings()
+    def test_nullable_null_default(self):
+        self.create_fixture(typed(
+            int,
+            default_value=None,
+            nullable=True,
+        ))
+        loader = load_from_dict()
+
+        config = configure(self.registry.defaults, self.metadata, loader)
+        assert_that(config, has_entries(
+            foo=has_entries(
+                value=None,
+            ),
+        ))
+
+    @check_no_warnings()
     def test_valid_default_factory(self):
         self.create_fixture(typed(list, default_factory=list))
         loader = load_from_dict()

--- a/microcosm/tests/config/test_validation.py
+++ b/microcosm/tests/config/test_validation.py
@@ -71,6 +71,18 @@ class TestValidation:
         ))
 
     @check_no_warnings()
+    def test_false_default(self):
+        self.create_fixture(typed(bool, default_value=False))
+        loader = load_from_dict()
+
+        config = configure(self.registry.defaults, self.metadata, loader)
+        assert_that(config, has_entries(
+            foo=has_entries(
+                value=False,
+            ),
+        ))
+
+    @check_no_warnings()
     def test_valid_default_factory(self):
         self.create_fixture(typed(list, default_factory=list))
         loader = load_from_dict()

--- a/microcosm/tests/config/test_validation.py
+++ b/microcosm/tests/config/test_validation.py
@@ -25,6 +25,7 @@ from microcosm.registry import Registry
 from microcosm.tests.config.check_warnings import (
     check_no_warnings,
     check_requirements_exactly_one_warning,
+    check_unsupported_arg_warning,
 )
 
 
@@ -267,6 +268,19 @@ class TestValidation:
         assert_that(config, has_entries(
             foo=has_entries(
                 value=1,
+            ),
+        ))
+
+    @check_unsupported_arg_warning()
+    def test_unsupported_arg(self):
+        self.create_fixture(required(int, mock_value=0, spaghetti="foo"))
+        loader = load_from_dict()
+
+        metadata = Metadata("test", testing=True)
+        config = configure(self.registry.defaults, metadata, loader)
+        assert_that(config, has_entries(
+            foo=has_entries(
+                value=0,
             ),
         ))
 


### PR DESCRIPTION
We add support for providing `default_factory` argument to `typed`, which will be called to construct the default value.

We also modify `Requirement` so that the user must provide **exactly one** of the following:
- `required=True`,
- `default_value=...`,
- `default_factory=...`.