### PR TITLE
Fix default value for tracing enable

### DIFF
--- a/microcosm/tracing.py
+++ b/microcosm/tracing.py
@@ -14,7 +14,7 @@ SPAN_NAME = "span_name"
 
 @binding("tracer")
 @defaults(
-    enabled=typed(boolean, default=False),
+    enabled=typed(boolean, default_value=False),
     sample_type="ratelimiting",
     sample_param=typed(int, 10),
     sampling_port=typed(int, DEFAULT_SAMPLING_PORT),


### PR DESCRIPTION
default => default_value (defaults to `None` otherwise, which is
incorrect).