### PR TITLE
 Whitelist tags added to jaeger span. 

### DIFF
--- a/microcosm/opaque.py
+++ b/microcosm/opaque.py
@@ -27,7 +27,7 @@ from opentracing.ext import tags
 from opentracing.propagation import Format
 from opentracing_instrumentation.request_context import span_in_context
 
-from microcosm.tracing import SPAN_NAME, OPAQUE_KEY_WHITE_LIST
+from microcosm.tracing import OPAQUE_KEY_WHITE_LIST, SPAN_NAME
 
 
 def _make_initializer(opaque):

--- a/microcosm/opaque.py
+++ b/microcosm/opaque.py
@@ -27,7 +27,7 @@ from opentracing.ext import tags
 from opentracing.propagation import Format
 from opentracing_instrumentation.request_context import span_in_context
 
-from microcosm.tracing import SPAN_NAME
+from microcosm.tracing import SPAN_NAME, OPAQUE_KEY_WHITE_LIST
 
 
 def _make_initializer(opaque):
@@ -73,7 +73,8 @@ def _make_initializer(opaque):
             Copy opaque tags into tracer tags.
             """
             for key, value in opaque.as_dict().items():
-                span.set_tag(key, value)
+                if key.lower() in OPAQUE_KEY_WHITE_LIST:
+                    span.set_tag(key, value)
 
         def pass_span_context_to_children(self, span):
             """

--- a/microcosm/tracing.py
+++ b/microcosm/tracing.py
@@ -4,12 +4,18 @@ from jaeger_client.config import (
     DEFAULT_SAMPLING_PORT,
     Config,
 )
+from jaeger_client.constants import TRACE_ID_HEADER
 
 from microcosm.api import binding, defaults, typed
 from microcosm.config.types import boolean
 
 
 SPAN_NAME = "span_name"
+OPAQUE_KEY_WHITE_LIST = [
+    "x-request-user",
+    "x-request-id",
+    TRACE_ID_HEADER,
+]
 
 
 @binding("tracer")


### PR DESCRIPTION
Jaeger keeps references to all tags it sees in memory causing a memory
leak if tags are used too liberally.