### PR TITLE
Fix tornado version ranges

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,10 @@ setup(
     install_requires=[
         "contextdecorator>=0.10.0",
         "inflection>=0.3.1",
+        # There is a competing upper version requirement for tornado
+        # between jaeger and open-tracing, the latter of which allows up to 6
+        # while jaeger 4.0 only allows up to 5.
+        "tornado<5",
         "jaeger-client>=4.0.0",
         "lazy>=1.3",
         "opentracing-instrumentation>=3.0.1",


### PR DESCRIPTION
The current released version of jaeger (4.0.0) only allows tornado <5,
while opentracing allows up to 6. This will cause builds to break
non-deterministically, as the latter may resolve its dependencies
before the former.

Interestingly, `master` specifies <6 (https://github.com/jaegertracing/jaeger-client-python/blob/master/setup.py#L42), so this will eventually become moot.