### PR TITLE
Remove tornado<5 pin as latest versions of jaeger and opentracing aligned on requiring tornado<6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,13 +22,9 @@ setup(
     install_requires=[
         "contextdecorator>=0.10.0",
         "inflection>=0.3.1",
-        # There is a competing upper version requirement for tornado
-        # between jaeger and open-tracing, the latter of which allows up to 6
-        # while jaeger 4.0 only allows up to 5.
-        "tornado<5",
-        "jaeger-client>=4.0.0",
+        "jaeger-client>=4.1.0",
         "lazy>=1.3",
-        "opentracing-instrumentation>=3.0.1",
+        "opentracing-instrumentation>=3.2.0",
     ],
     setup_requires=[
         "nose>=1.3.6",


### PR DESCRIPTION
As of latest `jaeger-client` and `opentracing-instrumentation`, it seems like they have re-converged on same tornado version upper req (tornado<6), which is a good thing since it means we can use `microcosm` again with jupyter notebooks..

See below for some further proof:
```
ERROR: opentracing-instrumentation 3.2.0 has requirement tornado<6,>=4.1, but you'll have tornado 6.0.3 which is incompatible.
ERROR: microcosm 2.12.2 has requirement tornado<5, but you'll have tornado 6.0.3 which is incompatible.
ERROR: jaeger-client 4.1.0 has requirement tornado<6,>=4.3, but you'll have tornado 6.0.3 which is incompatible.
```