### PR TITLE
Fix boolean typed config

### DIFF
--- a/microcosm/config/model.py
+++ b/microcosm/config/model.py
@@ -5,6 +5,7 @@ Configuration modeling, loading, and validation.
 from warnings import warn
 
 from microcosm.config.sentinel import UNSET
+from microcosm.config.types import boolean
 from microcosm.errors import ValidationError
 
 
@@ -154,6 +155,11 @@ class Requirement:
                 f"but got {[default_value, default_factory, required]}"
             )
 
+    def _cast_to_type(self, value):
+        if self.type == bool:
+            return boolean(value)
+        return self.type(value)
+
     def validate(self, metadata, path, value):
         """
         Validate this requirement.
@@ -176,6 +182,6 @@ class Requirement:
             if value is None and self.nullable:
                 return value
 
-            return self.type(value)
+            return self._cast_to_type(value)
         except (ValueError, TypeError):
             raise ValidationError(f"Missing required configuration for: {'.'.join(path)}: {value}")

--- a/microcosm/opaque.py
+++ b/microcosm/opaque.py
@@ -18,7 +18,7 @@ Combining opaque data across an entire fleet of services allows for consistent t
 easier debugging of distributed operations.
 
 """
-from collections import MutableMapping
+from collections.abc import MutableMapping
 from contextlib import ContextDecorator, ExitStack
 from copy import deepcopy
 from types import MethodType

--- a/microcosm/tests/config/check_warnings.py
+++ b/microcosm/tests/config/check_warnings.py
@@ -13,13 +13,13 @@ from hamcrest import (
 
 @contextmanager
 def check_warning(message):
-    with warnings.catch_warnings(record=True) as w:
+    with warnings.catch_warnings(record=True) as caught_warnings:
         warnings.simplefilter("always")
 
         yield
 
-        assert_that(w, has_length(1))
-        warning = w[-1]
+        assert_that(caught_warnings, has_length(1))
+        warning = caught_warnings[-1]
 
         assert_that(str(warning.message), contains_string(message))
         assert_that(warning.category, is_(equal_to(FutureWarning)))
@@ -35,10 +35,11 @@ def check_unsupported_arg_warning():
 
 @contextmanager
 def check_no_warnings():
-    with warnings.catch_warnings(record=True) as w:
+    with warnings.catch_warnings(record=True) as caught_warnings:
         warnings.simplefilter("always")
 
         yield
 
-        if w:
-            assert_that(w, is_(empty()), w[-1].message)
+        caught_warnings = [warning for warning in caught_warnings if "virtualenvs" not in warning.filename]
+        if caught_warnings:
+            assert_that(caught_warnings, is_(empty()), caught_warnings[-1].message)

--- a/microcosm/tests/config/test_validation.py
+++ b/microcosm/tests/config/test_validation.py
@@ -35,17 +35,15 @@ class TestValidation:
         self.metadata = Metadata("test")
         self.registry = Registry()
 
-    def create_fixture(self, requirement):
+    def create_fixture(self, **config_dict):
         @binding("foo", registry=self.registry)
-        @defaults(
-            value=requirement,
-        )
+        @defaults(**config_dict)
         def configure_foo(graph):
             return graph.foo.value
 
     @check_no_warnings()
     def test_valid(self):
-        self.create_fixture(required(int))
+        self.create_fixture(value=required(int))
         loader = load_from_dict(
             foo=dict(
                 value="1",
@@ -61,7 +59,7 @@ class TestValidation:
 
     @check_no_warnings()
     def test_valid_default(self):
-        self.create_fixture(typed(int, default_value="1"))
+        self.create_fixture(value=typed(int, default_value="1"))
         loader = load_from_dict()
 
         config = configure(self.registry.defaults, self.metadata, loader)
@@ -73,7 +71,7 @@ class TestValidation:
 
     @check_no_warnings()
     def test_false_default(self):
-        self.create_fixture(typed(bool, default_value=False))
+        self.create_fixture(value=typed(bool, default_value=False))
         loader = load_from_dict()
 
         config = configure(self.registry.defaults, self.metadata, loader)
@@ -85,7 +83,7 @@ class TestValidation:
 
     @check_no_warnings()
     def test_nullable(self):
-        self.create_fixture(typed(
+        self.create_fixture(value=typed(
             int,
             default_value=0,
             nullable=True,
@@ -103,7 +101,7 @@ class TestValidation:
 
     @check_no_warnings()
     def test_nullable_null_default(self):
-        self.create_fixture(typed(
+        self.create_fixture(value=typed(
             int,
             default_value=None,
             nullable=True,
@@ -119,7 +117,7 @@ class TestValidation:
 
     @check_no_warnings()
     def test_null_default_implies_nullable(self):
-        self.create_fixture(typed(int, default_value=None))
+        self.create_fixture(value=typed(int, default_value=None))
         loader = load_from_dict()
 
         config = configure(self.registry.defaults, self.metadata, loader)
@@ -131,7 +129,7 @@ class TestValidation:
 
     @check_no_warnings()
     def test_valid_default_factory(self):
-        self.create_fixture(typed(list, default_factory=list))
+        self.create_fixture(value=typed(list, default_factory=list))
         loader = load_from_dict()
 
         config = configure(self.registry.defaults, self.metadata, loader)
@@ -143,7 +141,7 @@ class TestValidation:
 
     @check_no_warnings()
     def test_invalid_missing(self):
-        self.create_fixture(required(int))
+        self.create_fixture(value=required(int))
         loader = load_from_dict()
 
         assert_that(
@@ -153,7 +151,7 @@ class TestValidation:
 
     @check_no_warnings()
     def test_invalid_malformed(self):
-        self.create_fixture(required(int))
+        self.create_fixture(value=required(int))
         loader = load_from_dict(
             foo=dict(
                 value="bar",
@@ -167,7 +165,7 @@ class TestValidation:
 
     @check_no_warnings()
     def test_invalid_none(self):
-        self.create_fixture(required(int))
+        self.create_fixture(value=required(int))
         loader = load_from_dict(
             foo=dict(
                 value=None,
@@ -181,7 +179,7 @@ class TestValidation:
 
     @check_no_warnings()
     def test_mock_value(self):
-        self.create_fixture(required(boolean, mock_value="true"))
+        self.create_fixture(value=required(boolean, mock_value="true"))
         loader = load_from_dict()
 
         metadata = Metadata("test", testing=True)
@@ -194,7 +192,7 @@ class TestValidation:
 
     @check_no_warnings()
     def test_comma_separated_list_converted(self):
-        self.create_fixture(required(comma_separated_list, mock_value="abc,def,ghi"))
+        self.create_fixture(value=required(comma_separated_list, mock_value="abc,def,ghi"))
         loader = load_from_dict()
 
         metadata = Metadata("test", testing=True)
@@ -207,7 +205,7 @@ class TestValidation:
 
     @check_no_warnings()
     def test_comma_separated_list_empty(self):
-        self.create_fixture(required(comma_separated_list, mock_value=""))
+        self.create_fixture(value=required(comma_separated_list, mock_value=""))
         loader = load_from_dict()
 
         metadata = Metadata("test", testing=True)
@@ -220,7 +218,7 @@ class TestValidation:
 
     @check_no_warnings()
     def test_comma_separated_list_unconverted(self):
-        self.create_fixture(required(comma_separated_list, mock_value=["abc", "def", "ghi"]))
+        self.create_fixture(value=required(comma_separated_list, mock_value=["abc", "def", "ghi"]))
         loader = load_from_dict()
 
         metadata = Metadata("test", testing=True)
@@ -233,7 +231,7 @@ class TestValidation:
 
     @check_no_warnings()
     def test_typed_converted(self):
-        self.create_fixture(required(int))
+        self.create_fixture(value=required(int))
         loader = load_from_dict(
             foo=dict(
                 value="1",
@@ -249,39 +247,34 @@ class TestValidation:
 
     @check_no_warnings()
     def test_boolean_typed_converted(self):
-        self.create_fixture(typed(bool, default_value=None))
+        self.create_fixture(
+            bar=typed(bool, default_value=None),
+            baz=typed(bool, default_value=None),
+            qux=typed(bool, default_value=None),
+            kog=typed(bool, default_value=None),
+        )
         loader = load_from_dict(
             foo=dict(
-                value="False",
+                bar="False",
+                baz="True",
+                qux="false",
+                kog="true",
             ),
         )
 
         config = configure(self.registry.defaults, self.metadata, loader)
         assert_that(config, has_entries(
             foo=has_entries(
-                value=False,
-            ),
-        ))
-
-    @check_no_warnings()
-    def test_lowercase_boolean_typed_converted(self):
-        self.create_fixture(typed(bool, default_value=None))
-        loader = load_from_dict(
-            foo=dict(
-                value="false",
-            ),
-        )
-
-        config = configure(self.registry.defaults, self.metadata, loader)
-        assert_that(config, has_entries(
-            foo=has_entries(
-                value=False,
+                bar=False,
+                baz=True,
+                qux=False,
+                kog=True,
             ),
         ))
 
     @check_requirements_exactly_one_warning()
     def test_missing_default(self):
-        self.create_fixture(typed(int))
+        self.create_fixture(value=typed(int))
         loader = load_from_dict()
 
         config = configure(self.registry.defaults, self.metadata, loader)
@@ -293,7 +286,7 @@ class TestValidation:
 
     @check_requirements_exactly_one_warning()
     def test_default_and_required(self):
-        self.create_fixture(required(int, default_value="1"))
+        self.create_fixture(value=required(int, default_value="1"))
         loader = load_from_dict()
 
         config = configure(self.registry.defaults, self.metadata, loader)
@@ -305,7 +298,7 @@ class TestValidation:
 
     @check_unsupported_arg_warning()
     def test_unsupported_arg(self):
-        self.create_fixture(required(int, mock_value=0, spaghetti="foo"))
+        self.create_fixture(value=required(int, mock_value=0, spaghetti="foo"))
         loader = load_from_dict()
 
         metadata = Metadata("test", testing=True)

--- a/microcosm/tests/config/test_validation.py
+++ b/microcosm/tests/config/test_validation.py
@@ -247,6 +247,38 @@ class TestValidation:
             ),
         ))
 
+    @check_no_warnings()
+    def test_boolean_typed_converted(self):
+        self.create_fixture(typed(bool, default_value=None))
+        loader = load_from_dict(
+            foo=dict(
+                value="False",
+            ),
+        )
+
+        config = configure(self.registry.defaults, self.metadata, loader)
+        assert_that(config, has_entries(
+            foo=has_entries(
+                value=False,
+            ),
+        ))
+
+    @check_no_warnings()
+    def test_lowercase_boolean_typed_converted(self):
+        self.create_fixture(typed(bool, default_value=None))
+        loader = load_from_dict(
+            foo=dict(
+                value="false",
+            ),
+        )
+
+        config = configure(self.registry.defaults, self.metadata, loader)
+        assert_that(config, has_entries(
+            foo=has_entries(
+                value=False,
+            ),
+        ))
+
     @check_requirements_exactly_one_warning()
     def test_missing_default(self):
         self.create_fixture(typed(int))


### PR DESCRIPTION
**Why?**
In many cases configuration is passed to the application as a string (e.g. environment variable). We use the `typed` function to convert those strings to the proper type, e.g.
```
typed(int, default_value=1)
typed(float, default_value=1.5)
```
However using `typed(bool, ...)` doesn't work, the current way to do it is to use the `boolean` type instead, defined in this library. This PR makes it so `bool` also works.

**What?**
- Use existing `boolean` function for proper type conversion of `bool`.
- Fix `check_no_warnings` decorator.