### PR TITLE
Remove deprecation warning

### DIFF
--- a/microcosm/opaque.py
+++ b/microcosm/opaque.py
@@ -18,7 +18,7 @@ Combining opaque data across an entire fleet of services allows for consistent t
 easier debugging of distributed operations.
 
 """
-from collections import MutableMapping
+from collections.abc import MutableMapping
 from contextlib import ContextDecorator, ExitStack
 from copy import deepcopy
 from types import MethodType


### PR DESCRIPTION
Silences:
> DeprecationWarning: Using or importing the ABCs from 'collections'
> instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working