### PR TITLE
Cleanup: Resolve warning, remove unneeded package

### DIFF
--- a/microcosm/tests/test_hooks.py
+++ b/microcosm/tests/test_hooks.py
@@ -2,7 +2,7 @@
 Test hook invocation.
 
 """
-from hamcrest import assert_that, contains
+from hamcrest import assert_that, contains_exactly
 
 from microcosm.api import binding, create_object_graph
 from microcosm.hooks import on_resolve
@@ -47,7 +47,7 @@ class TestHooks:
         graph.use("foo")
         graph.lock()
 
-        assert_that(graph.foo.callbacks, contains("baz"))
+        assert_that(graph.foo.callbacks, contains_exactly("baz"))
 
     def test_on_resolve_foo_again(self):
         """
@@ -58,7 +58,7 @@ class TestHooks:
         graph.use("foo")
         graph.lock()
 
-        assert_that(graph.foo.callbacks, contains("baz"))
+        assert_that(graph.foo.callbacks, contains_exactly("baz"))
 
     def test_on_resolve_foo_subfoo(self):
         """
@@ -71,8 +71,8 @@ class TestHooks:
         graph.use("subfoo")
         graph.lock()
 
-        assert_that(graph.foo.callbacks, contains("baz"))
-        assert_that(graph.subfoo.callbacks, contains("qux"))
+        assert_that(graph.foo.callbacks, contains_exactly("baz"))
+        assert_that(graph.subfoo.callbacks, contains_exactly("qux"))
 
     def test_on_resolve_bar_once(self):
         """
@@ -83,7 +83,7 @@ class TestHooks:
         graph.use("bar")
         graph.lock()
 
-        assert_that(graph.bar.callbacks, contains("baz"))
+        assert_that(graph.bar.callbacks, contains_exactly("baz"))
 
     def test_on_resolve_bar_again(self):
         """
@@ -94,4 +94,4 @@ class TestHooks:
         graph.use("bar")
         graph.lock()
 
-        assert_that(graph.bar.callbacks, contains("baz"))
+        assert_that(graph.bar.callbacks, contains_exactly("baz"))

--- a/microcosm/tests/test_object_graph.py
+++ b/microcosm/tests/test_object_graph.py
@@ -7,7 +7,7 @@ from unittest.mock import Mock
 from hamcrest import (
     assert_that,
     calling,
-    contains,
+    contains_exactly,
     equal_to,
     has_items,
     instance_of,
@@ -73,9 +73,9 @@ def test_object_graph_use():
     assert_that(
         list(graph.items()),
         has_items(
-            contains("parent", is_(instance_of(Parent))),
-            contains("child", is_(instance_of(Child))),
-            contains("hello_world", is_(equal_to("hello world"))),
+            contains_exactly("parent", is_(instance_of(Parent))),
+            contains_exactly("child", is_(instance_of(Child))),
+            contains_exactly("hello_world", is_(equal_to("hello world"))),
         )
     )
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setup(
     python_requires=">=3.6",
     keywords="microcosm",
     install_requires=[
-        "contextdecorator>=0.10.0",
         "inflection>=0.3.1",
         "lazy>=1.3",
     ],


### PR DESCRIPTION
- Resolve deprecation warning for pyhamcrest contains
- Remove backport package `contextdecorator`
https://pypi.org/project/contextdecorator/
> The contextdecorator module is a backport of new features added to the contextlib module in Python 3.2. contextdecorator works with Python 2.4+ including Python 3.