### PR TITLE
Expand Typing definitions, PEP-561 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ nosetests.xml
 coverage.xml
 *,cover
 cover
+coverage/
 
 # Translations
 *.mo

--- a/microcosm/caching.py
+++ b/microcosm/caching.py
@@ -8,32 +8,36 @@ Alternate cache implementations can be used to speed up performance
 
 """
 from collections import defaultdict
-from collections.abc import MutableMapping
-from typing import Any, Mapping
+from typing import (
+    Any,
+    Dict,
+    MutableMapping,
+    Optional,
+)
 
 
-class Cache(MutableMapping):
+class Cache(MutableMapping[str, str]):
     """
     A cache supports the basic dictionary interface and defines a name.
 
     """
     @classmethod
-    def name(self):
+    def name(cls):
         raise NotImplementedError
 
 
-class NaiveCache(dict, Cache):
+class NaiveCache(Dict[Any, Any], Cache):
     """
     Cache components in a dictionary.
 
     Under most circumstances, every instantiation of an object graph
-    results in a new `NaiveCache` and a new instantitation of components.
+    results in a new `NaiveCache` and a new instantiation of components.
 
     Most applications will want a `NaiveCache` for "real" usage.
 
     """
     @classmethod
-    def name(self):
+    def name(cls):
         return "naive"
 
 
@@ -48,10 +52,10 @@ class ProcessCache(Cache):
     time (at the expense of a "clean slate" testing context).
 
     """
-    CACHES: Mapping[str, Mapping[str, Any]] = defaultdict(dict)
+    CACHES: Dict[str, Dict[str, Any]] = defaultdict(dict)
 
     @classmethod
-    def name(self):
+    def name(cls):
         return "process"
 
     def __init__(self, scope="default"):
@@ -76,7 +80,7 @@ class ProcessCache(Cache):
         return len(ProcessCache.CACHES[self.scope])
 
 
-def create_cache(name):
+def create_cache(name: Optional[str]):
     """
     Create a cache by name.
 
@@ -87,4 +91,4 @@ def create_cache(name):
         subclass.name(): subclass
         for subclass in Cache.__subclasses__()
     }
-    return caches.get(name, NaiveCache)()
+    return caches.get(name, NaiveCache)()  # type: ignore[abstract]

--- a/microcosm/config/api.py
+++ b/microcosm/config/api.py
@@ -2,11 +2,19 @@
 Configuration API.
 
 """
+from typing import Any, Dict
+
 from microcosm.config.model import Configuration
 from microcosm.config.validation import validate
+from microcosm.metadata import Metadata
+from microcosm.typing import Loader
 
 
-def configure(defaults, metadata, loader):
+def configure(
+    defaults: Dict[str, Any],
+    metadata: Metadata,
+    loader: Loader,
+) -> Configuration:
     """
     Build a fresh configuration.
 

--- a/microcosm/config/model.py
+++ b/microcosm/config/model.py
@@ -2,6 +2,7 @@
 Configuration modeling, loading, and validation.
 
 """
+from typing import Any, Dict, Optional
 from warnings import warn
 
 from microcosm.config.sentinel import UNSET
@@ -9,7 +10,7 @@ from microcosm.config.types import boolean
 from microcosm.errors import ValidationError
 
 
-class Configuration(dict):
+class Configuration(Dict[Any, Any]):
     """
     Nested attribute dictionary with recursive merging for modeling configuration.
 
@@ -20,7 +21,11 @@ class Configuration(dict):
     but are also not needed (yet).
 
     """
-    def __init__(self, dct=None, **kwargs):
+    def __init__(
+        self,
+        dct: Optional[Dict[Any, Any]] = None,
+        **kwargs: Any
+    ) -> None:
         if dct is None:
             dct = {}
         if kwargs:
@@ -29,7 +34,7 @@ class Configuration(dict):
         for key, value in dct.items():
             setattr(self, key, value)
 
-    def __setattr__(self, name, value):
+    def __setattr__(self, name: str, value) -> None:
         if isinstance(value, list):
             value = [
                 self.__class__(x)
@@ -45,7 +50,7 @@ class Configuration(dict):
         super(Configuration, self).__setattr__(name, value)
         super(Configuration, self).__setitem__(name, value)
 
-    def merge(self, dct=None, **kwargs):
+    def merge(self, dct: Optional[Dict[Any, Any]] = None, **kwargs) -> None:
         """
         Recursively merge a dictionary or kwargs into the current dict.
 
@@ -57,9 +62,9 @@ class Configuration(dict):
 
         for key, value in dct.items():
             if all((
-                    isinstance(value, dict),
-                    isinstance(self.get(key), Configuration),
-                    getattr(self.get(key), "__merge__", True),
+                isinstance(value, dict),
+                isinstance(self.get(key), Configuration),
+                getattr(self.get(key), "__merge__", True),
             )):
                 # recursively merge
                 self[key].merge(value)
@@ -91,7 +96,7 @@ class Requirement:
     ):
         """
         :param type: a type callable
-        :param mock_value: a default value to use durint testing (only)
+        :param mock_value: a default value to use during testing (only)
 
         """
         self.type = type

--- a/microcosm/config/sentinel.py
+++ b/microcosm/config/sentinel.py
@@ -1,5 +1,5 @@
 class _Unset:
-    def __repr__(self):
+    def __repr__(self) -> str:
         return '<value not set>'
 
 

--- a/microcosm/config/types.py
+++ b/microcosm/config/types.py
@@ -3,9 +3,10 @@ Configuration types.
 
 """
 from distutils.util import strtobool
+from typing import List, Union
 
 
-def boolean(value):
+def boolean(value: Union[bool, str]) -> bool:
     """
     Configuration-friendly boolean type converter.
 
@@ -18,10 +19,10 @@ def boolean(value):
     if value == "":
         return False
 
-    return strtobool(value)
+    return bool(strtobool(value))
 
 
-def comma_separated_list(value):
+def comma_separated_list(value: Union[List[str], str]) -> List[str]:
     """
     Configuration-friendly list type converter.
 

--- a/microcosm/config/validation.py
+++ b/microcosm/config/validation.py
@@ -2,10 +2,13 @@
 Validation for configuration.
 
 """
-from microcosm.config.model import Requirement
+from typing import Any, Dict, Tuple
+
+from microcosm.config.model import Configuration, Requirement
+from microcosm.metadata import Metadata
 
 
-def required(*args, **kwargs):
+def required(*args, **kwargs) -> Requirement:
     """
     Fluent requirement declaration.
 
@@ -13,15 +16,16 @@ def required(*args, **kwargs):
     return Requirement(*args, **kwargs)
 
 
-def typed(*args, **kwargs):
+def typed(*args, **kwargs) -> Requirement:
     """
     Fluent requirement declaration.
 
     """
-    return Requirement(*args, required=False, **kwargs)
+    kwargs["required"] = False
+    return Requirement(*args, **kwargs)
 
 
-def validate(defaults, metadata, config):
+def validate(defaults, metadata: Metadata, config: Configuration) -> None:
     """
     Validate configuration.
 
@@ -32,7 +36,7 @@ def validate(defaults, metadata, config):
             parent[path[-1]] = default.validate(metadata, path, value)
 
 
-def zip_dicts(left, right, prefix=()):
+def zip_dicts(left: Dict[Any, Any], right: Dict[Any, Any], prefix: Tuple[str, ...] = ()):
     """
     Modified zip through two dictionaries.
 

--- a/microcosm/decorators.py
+++ b/microcosm/decorators.py
@@ -2,23 +2,25 @@
 Factory decorators
 
 """
+from typing import Callable, Optional
+
 from microcosm.constants import DEFAULTS
-from microcosm.registry import _registry
+from microcosm.registry import Registry, _registry
 
 
-def binding(key, registry=None):
+def binding(key: str, registry: Optional[Registry] = None) -> Callable[..., None]:
     """
     Creates a decorator that binds a factory function to a key.
 
     :param key: the binding key
-    :param: registry: the registry to bind to; defaults to the global registry
+    :param registry: the registry to bind to; defaults to the global registry
 
     """
     if registry is None:
         registry = _registry
 
     def decorator(func):
-        registry.bind(key, func)
+        registry.bind(key, func)  # type: ignore[union-attr]
         return func
     return decorator
 

--- a/microcosm/hooks.py
+++ b/microcosm/hooks.py
@@ -37,16 +37,17 @@ graph load time:
 
 
 """
+from typing import Any, Callable
 
 
 ON_RESOLVE = "_microcosm_on_resolve_"
 
 
-def _get_hook_name(hook_prefix, target_cls):
+def _get_hook_name(hook_prefix: str, target_cls: type):
     return f"{hook_prefix}_{target_cls.__name__}"
 
 
-def _invoke_hook(hook_prefix, target_component):
+def _invoke_hook(hook_prefix: str, target_component: Any) -> None:
     """
     Generic hook invocation.
 
@@ -64,7 +65,7 @@ def _invoke_hook(hook_prefix, target_component):
         pass
 
 
-def _register_hook(hook_prefix, target_cls, func, *args, **kwargs):
+def _register_hook(hook_prefix: str, target_cls: type, func: Callable[[Any, Any], None], *args, **kwargs) -> None:
     """
     Generic hook registration.
 
@@ -77,7 +78,7 @@ def _register_hook(hook_prefix, target_cls, func, *args, **kwargs):
         setattr(target_cls, hook_name, [call])
 
 
-def invoke_resolve_hook(target):
+def invoke_resolve_hook(target: Any) -> None:
     """
     Invoke resolution hook.
 
@@ -85,7 +86,7 @@ def invoke_resolve_hook(target):
     return _invoke_hook(ON_RESOLVE, target)
 
 
-def on_resolve(target, func, *args, **kwargs):
+def on_resolve(target: Any, func: Callable[..., None], *args, **kwargs) -> None:
     """
     Register a resolution hook.
 

--- a/microcosm/loaders/__init__.py
+++ b/microcosm/loaders/__init__.py
@@ -8,6 +8,8 @@ Configuration might be loaded from a file, from environment variables,
 or from an external service.
 
 """
+from typing import Any, Dict, Optional
+
 from microcosm.config.model import Configuration
 from microcosm.loaders.compose import load_each, two_stage_loader  # noqa: F401
 from microcosm.loaders.environment import (  # noqa: F401
@@ -17,9 +19,10 @@ from microcosm.loaders.environment import (  # noqa: F401
 from microcosm.loaders.keys import expand_config  # noqa: F401
 from microcosm.loaders.settings import load_from_json_file  # noqa: F401
 from microcosm.metadata import Metadata
+from microcosm.typing import Loader
 
 
-def load_from_dict(dct=None, **kwargs):
+def load_from_dict(dct: Optional[Dict[Any, Any]] = None, **kwargs) -> Loader:
     """
     Load configuration from a dictionary.
 
@@ -27,10 +30,10 @@ def load_from_dict(dct=None, **kwargs):
     dct = dct or dict()
     dct.update(kwargs)
 
-    def _load_from_dict(metadata):
+    def _load_from_dict(metadata: Metadata) -> Configuration:
         return Configuration(dct)
     return _load_from_dict
 
 
-def empty_loader(metadata: Metadata):
+def empty_loader(metadata: Metadata) -> Configuration:
     return Configuration()

--- a/microcosm/loaders/environment.py
+++ b/microcosm/loaders/environment.py
@@ -1,5 +1,5 @@
 """
-Enviroment-variable based loaders.
+Environment-variable based loaders.
 
 Uses a naming convention to map environment variables to nested configuration.
 
@@ -35,7 +35,7 @@ def _load_from_environ(metadata, value_func=None):
     prefix = metadata.name.upper().replace("-", "_")
 
     return expand_config(
-        environ,
+        dict(environ),
         separator="__",
         skip_to=1,
         key_parts_filter=lambda key_parts: len(key_parts) > 1 and key_parts[0] == prefix,

--- a/microcosm/loaders/keys.py
+++ b/microcosm/loaders/keys.py
@@ -2,26 +2,34 @@
 Key expansion.
 
 """
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+)
 
 
-def expand_config(dct,
-                  separator='.',
-                  skip_to=0,
-                  key_func=lambda key: key.lower(),
-                  key_parts_filter=lambda key_parts: True,
-                  value_func=lambda value: value):
+def expand_config(
+    dct: Dict[Any, Any],
+    separator: str = '.',
+    skip_to: int = 0,
+    key_func: Callable[[str], str] = lambda key: key.lower(),
+    key_parts_filter: Callable[[List[str]], bool] = lambda key_parts: True,
+    value_func: Callable[[str], str] = lambda value: value
+):
     """
     Expand a dictionary recursively by splitting keys along the separator.
 
     :param dct: a non-recursive dictionary
-    :param separator: a separator charactor for splitting dictionary keys
+    :param separator: a separator character for splitting dictionary keys
     :param skip_to: index to start splitting keys on; can be used to skip over a key prefix
     :param key_func: a key mapping function
     :param key_parts_filter: a filter function for excluding keys
     :param value_func: a value mapping func
 
     """
-    config = {}
+    config: Dict[str, Any] = {}
 
     for key, value in dct.items():
         key_separator = separator(key) if callable(separator) else separator

--- a/microcosm/loaders/settings.py
+++ b/microcosm/loaders/settings.py
@@ -7,11 +7,20 @@ and consumed using a customizable load function (default: json).
 """
 from json import loads
 from os import environ
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Mapping,
+    Optional,
+)
 
 from inflection import underscore
 
+from microcosm.metadata import Metadata
 
-def get_config_filename(metadata):
+
+def get_config_filename(metadata: Metadata) -> Optional[str]:
     """
     Derive a configuration file name from the FOO_SETTINGS
     environment variable.
@@ -24,7 +33,7 @@ def get_config_filename(metadata):
         return None
 
 
-def _load_from_file(metadata, load_func):
+def _load_from_file(metadata: Metadata, load_func: Callable[[str], Mapping[str, str]]) -> Dict[Any, Any]:
     """
     Load configuration from a file.
 
@@ -41,7 +50,7 @@ def _load_from_file(metadata, load_func):
         return dict(data)
 
 
-def load_from_json_file(metadata):
+def load_from_json_file(metadata: Metadata) -> Dict[Any, Any]:
     """
     Load configuration from a JSON file.
 

--- a/microcosm/metadata.py
+++ b/microcosm/metadata.py
@@ -4,6 +4,7 @@ Service metadata
 """
 from os.path import abspath, dirname, join
 from sys import modules
+from typing import Optional
 
 
 class Metadata:
@@ -14,7 +15,14 @@ class Metadata:
 
     """
 
-    def __init__(self, name, debug=False, testing=False, import_name=None, root_path=None):
+    def __init__(
+        self,
+        name: str,
+        debug: bool = False,
+        testing: bool = False,
+        import_name: Optional[str] = None,
+        root_path: Optional[str] = None,
+    ):
         """
         :param name: the name of the microservice
         :param debug: is development debugging enabled?

--- a/microcosm/profile.py
+++ b/microcosm/profile.py
@@ -7,7 +7,7 @@ from time import time
 
 class NoopProfiler:
 
-    def __call__(self, key):
+    def __call__(self, key: str) -> 'NoopProfiler':
         return self
 
     def __enter__(self):

--- a/microcosm/registry.py
+++ b/microcosm/registry.py
@@ -4,14 +4,23 @@ Registry of component factories.
 """
 from itertools import chain
 from pkg_resources import DistributionNotFound, iter_entry_points
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterator,
+    Tuple,
+)
 
 from lazy import lazy
 
 from microcosm.constants import DEFAULTS
 from microcosm.errors import AlreadyBoundError, NotBoundError
+from microcosm.typing import Component
 
 
-def get_defaults(func):
+# TODO This should use Factory type def
+def get_defaults(func: Callable[[Any], Component]) -> Dict[str, Any]:
     """
     Retrieve the defaults for a factory function.
 
@@ -30,7 +39,7 @@ class Registry:
         self.factories = {}
 
     @lazy
-    def entry_points(self):
+    def entry_points(self) -> Dict[str, Callable[[Any], Component]]:
         return {
             name: factory
             # NB: it's possible to have two entry points for the same name
@@ -40,7 +49,7 @@ class Registry:
         }
 
     @property
-    def all(self):
+    def all(self) -> Dict[str, Callable[[Any], Component]]:
         """
         Return a synthetic dictionary of all factories.
 
@@ -51,9 +60,9 @@ class Registry:
         }
 
     @property
-    def defaults(self):
+    def defaults(self) -> Dict[str, Dict[str, Any]]:
         """
-        Return a nested dicionary of all registered factory defaults.
+        Return a nested dictionary of all registered factory defaults.
 
         """
         return {
@@ -61,11 +70,11 @@ class Registry:
             for key, value in self.all.items()
         }
 
-    def bind(self, key, factory):
+    def bind(self, key: str, factory: Callable[[Any], Component]):
         """
         Bind a factory to a key.
 
-        :raises AlreadyBoundError: if the key is alrady bound
+        :raises AlreadyBoundError: if the key is already bound
 
         """
         if key in self.factories:
@@ -73,7 +82,7 @@ class Registry:
         else:
             self.factories[key] = factory
 
-    def resolve(self, key):
+    def resolve(self, key: str) -> Callable[[Any], Component]:
         """
         Resolve a key to a factory.
 
@@ -88,16 +97,16 @@ class Registry:
         except NotBoundError:
             return self._resolve_from_entry_point(key)
 
-    def _iter_entry_points(self):
+    def _iter_entry_points(self) -> Iterator[Tuple[str, Callable[[Any], Component]]]:
         for entry_point in iter_entry_points(group="microcosm.factories"):
             try:
                 factory = entry_point.load()
             except DistributionNotFound:
                 continue
 
-            yield (entry_point.name, factory)
+            yield entry_point.name, factory
 
-    def _resolve_from_binding(self, key):
+    def _resolve_from_binding(self, key: str) -> Callable[[Any], Component]:
         """
         Resolve using bindings.
 
@@ -107,7 +116,7 @@ class Registry:
         except KeyError:
             raise NotBoundError(key)
 
-    def _resolve_from_entry_point(self, key):
+    def _resolve_from_entry_point(self, key: str) -> Callable[[Any], Component]:
         """
         Resolve using entry points.
 

--- a/microcosm/scoping/decorators.py
+++ b/microcosm/scoping/decorators.py
@@ -6,7 +6,7 @@ from microcosm.decorators import binding
 from microcosm.scoping.factories import ScopedFactory
 
 
-def scoped_binding(key, default_scope=None, registry=None):
+def scoped_binding(key: str, default_scope=None, registry=None):
     def decorator(func):
         binding(key, registry)(ScopedFactory(key, func, default_scope))
         return func

--- a/microcosm/scoping/factories.py
+++ b/microcosm/scoping/factories.py
@@ -3,9 +3,12 @@ A factory that enables scoping.
 
 """
 from microcosm.config.api import configure
+from microcosm.config.model import Configuration
+from microcosm.object_graph import Factory, ObjectGraph
 from microcosm.registry import get_defaults
 from microcosm.scoping.object_graph import ScopedGraph
 from microcosm.scoping.proxies import ScopedProxy
+from microcosm.typing import Component
 
 
 class ScopedFactory:
@@ -32,7 +35,7 @@ class ScopedFactory:
     depending on the current scope.
 
     """
-    def __init__(self, key, func, default_scope=None):
+    def __init__(self, key: str, func: Factory, default_scope=None):
         self.key = key
         self.func = func
         self.current_scope = default_scope
@@ -43,7 +46,7 @@ class ScopedFactory:
         # NB: deliberately conflating false-y values
         return "{}.{}".format(self.current_scope or "", self.key)
 
-    def get_scoped_config(self, graph):
+    def get_scoped_config(self, graph: ObjectGraph) -> Configuration:
         """
         Compute a configuration using the current scope.
 
@@ -62,7 +65,7 @@ class ScopedFactory:
         }
         return configure(defaults, graph.metadata, loader)
 
-    def __call__(self, graph):
+    def __call__(self, graph: ObjectGraph) -> ScopedProxy:
         """
         Override component creation to use scoped config.
 
@@ -70,7 +73,7 @@ class ScopedFactory:
         self.resolve(graph)
         return ScopedProxy(graph, self)
 
-    def resolve(self, graph):
+    def resolve(self, graph: ObjectGraph) -> Component:
         """
         Resolve a scoped component, respecting the graph cache.
 
@@ -83,7 +86,7 @@ class ScopedFactory:
         graph.assign(self.scoped_key, component)
         return component
 
-    def create(self, graph):
+    def create(self, graph: ObjectGraph) -> Component:
         """
         Create a new scoped component.
 
@@ -93,7 +96,7 @@ class ScopedFactory:
         return self.func(scoped_graph)
 
     @classmethod
-    def infect(cls, graph, key, default_scope=None):
+    def infect(cls, graph: ObjectGraph, key: str, default_scope=None) -> Factory:
         """
         Forcibly convert an entry-point based factory to a ScopedFactory.
 

--- a/microcosm/scoping/object_graph.py
+++ b/microcosm/scoping/object_graph.py
@@ -2,9 +2,10 @@
 A view of the object graph that exposes only a subset of configuration.
 
 """
+from microcosm.object_graph import ObjectGraph
 
 
-class ScopedGraph:
+class ScopedGraph(ObjectGraph):
 
     def __init__(self, graph, config):
         self._graph = graph

--- a/microcosm/typing.py
+++ b/microcosm/typing.py
@@ -1,14 +1,15 @@
-from typing import Callable, Mapping
+from typing import Any, Callable, Union
 
 from microcosm.config.model import Configuration
 from microcosm.metadata import Metadata
 
 
+Component = Union[object, Any]
 # NB: Due to covariance / contravariance, we want the return value types to be
 # the most general possible, while the parameter types should be the most
-# specific. This setup results in these type definitiions being as permissive
+# specific. This setup results in these type definitions being as permissive
 # as possible. Then within two_stage_loader, we wrap the outputs of the
 # loaders in Configuration so that two_stage_loader returns the most specific
 # type possible, so that it can be used in as many situations as possible.
-Loader = Callable[[Metadata], Mapping]
-SecondaryLoader = Callable[[Metadata, Configuration], Mapping]
+Loader = Callable[[Metadata], Configuration]
+SecondaryLoader = Callable[[Metadata, Configuration], Configuration]

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,18 @@ multi_line_output = 3
 
 [mypy]
 ignore_missing_imports = True
+check_untyped_defs = True
+disallow_any_generics = True
+warn_no_return = True
+strict_optional = True
+no_implicit_optional = True
+warn_redundant_casts = True
+warn_unused_ignores = True
+show_error_codes = True
+warn_unreachable = True
+
+[mypy-microcosm.tests.*]
+ignore_errors = True
 
 [nosetests]
 with-coverage = True

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,9 @@ setup(
     author_email="engineering@globality.com",
     url="https://github.com/globality-corp/microcosm",
     packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
+    package_data={
+        "microcosm": ["py.typed"],
+    },
     include_package_data=True,
     zip_safe=False,
     python_requires=">=3.6",


### PR DESCRIPTION
- PEP 561 - support via 
```
    package_data = {
        'microcosm': ['py.typed'],
    },
```