### PR TITLE
Make opaque all lowercase

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.3.0
+current_version = 3.4.0
 commit = False
 tag = False
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,7 +211,7 @@ jobs:
             version=$(cat .bumpversion.cfg | awk '/current_version / {print $3}')
             python setup.py register -r pypi
             python setup.py sdist
-            twine upload --repository pypi dist/microcosm-postgres-${version}.tar.gz
+            twine upload --repository pypi dist/microcosm-${version}.tar.gz
 
 
 workflows:

--- a/microcosm/tests/test_opaque.py
+++ b/microcosm/tests/test_opaque.py
@@ -10,7 +10,7 @@ from hamcrest import (
 )
 
 from microcosm.api import binding, create_object_graph, load_from_dict
-from microcosm.opaque import Opaque
+from microcosm.opaque import NormalizedDict, Opaque
 
 
 THIS = "this"
@@ -25,6 +25,83 @@ def example_func(this, that):
         THIS: this,
         THAT: that,
     }
+
+
+def test_normalized_dict_init():
+    dct = NormalizedDict()
+    assert not dct
+
+    dct = NormalizedDict(foo="bar", Bar="Foo", baz="qux")
+    assert dct == {"foo": "bar", "bar": "Foo", "baz": "qux"}
+
+    dct = NormalizedDict([("foo-foo", "bar"), ("Bar_Bar", "Foo"), ("baz", "qux")])
+    assert dct == {"foo-foo": "bar", "bar_bar": "Foo", "baz": "qux"}
+
+    dct = NormalizedDict({"foo-foo": "bar", "Bar_Bar": "Foo", "baz": "qux"})
+    assert dct == {"foo-foo": "bar", "bar_bar": "Foo", "baz": "qux"}
+
+    dct = NormalizedDict.fromkeys(["foo", "bar"], 1)
+    assert dct == {"foo": 1, "bar": 1}
+
+
+def test_normalized_dict_setitem():
+    dct = NormalizedDict()
+    dct["FOO"] = "Bar"
+    assert dct["foo"] == "Bar"
+    assert dct.get("foo") == "Bar"
+
+    dct[(1, 1)] = "foo"
+    assert dct[(1, 1)] == "foo"
+
+
+def test_normalized_dict_getitem():
+    dct = NormalizedDict()
+    dct["foo"] = "bar"
+    assert dct["FOO"] == "bar"
+
+
+def test_normalized_dict_delitem():
+    dct = NormalizedDict()
+    dct["foo"] = "bar"
+    del dct["FOO"]
+    assert not dct
+    assert dct.get("foo") is None
+
+
+def test_normalized_dict_contains():
+    dct = NormalizedDict()
+    dct["foo"] = "bar"
+    assert "FOO" in dct
+    assert "bar" not in dct
+
+
+def test_normalized_dict_pop():
+    dct = NormalizedDict()
+    dct["foo"] = "bar"
+    assert dct.pop("FOO") == "bar"
+    assert not dct
+    assert dct.pop("bar", "baz") == "baz"
+
+
+def test_normalized_dict_get():
+    dct = NormalizedDict()
+    dct["foo"] = "bar"
+    assert dct.get("FOO") == "bar"
+    assert dct.get("FOO", "baz") == "bar"
+    assert dct.get("baz", "bar") == "bar"
+
+
+def test_normalized_dict_update():
+    dct = NormalizedDict()
+    dct["foo"] = "Bar"
+    dct.update({"FOO": "Baz", "bar": "Foo"})
+    assert dct == {"foo": "Baz", "bar": "Foo"}
+
+
+def test_normalized_dict_setdefault():
+    dct = NormalizedDict()
+    dct.setdefault("Foo", "bar")
+    assert dct["foo"] == "bar"
 
 
 def test_dict_usage():

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 
 project = "microcosm"
-version = "3.3.0"
+version = "3.4.0"
 
 setup(
     name=project,


### PR DESCRIPTION
Why?

Handling all variations of possible opaque keys in downstream code is awkward, especially if there's a need to merge same piece of information, but using slightly different keys, e.g. `x-request-id` vs `X-Request-Id`.

What?

Replaced internal opaque `_store` with `LowercaseDict` which has only lower-case keys.